### PR TITLE
[ENH] Cross-validation for BehavioralPLS

### DIFF
--- a/pyls/base.py
+++ b/pyls/base.py
@@ -174,9 +174,27 @@ class PLSResults(utils.DefDict):
             ucorr_ul=None, ucorr_ll=None, vcorr_ul=None, vcorr_ll=None
         )
 
+    class PLSCrossValidationResults(utils.DefDict):
+        """
+        PLS cross-validation results
+
+        Attributes
+        ----------
+        r_sqared : (T x I) np.ndarray
+            R-squared ("determination coefficient") for each of `T` predicted
+            behavioral scores against true behavioral scores across `I` train /
+            test split
+        pearson_r : (T x I) np.ndarray
+            Pearson's correlation for each of `T` predicted behavioral scores
+            against true behavioral scores across `I` train / test split
+        """
+        defaults = dict(
+            r_squared=None, pearson_r=None
+        )
+
     defaults = dict(
-        u=None, s=None, v=None, usc=None, vsc=None, lvcorrs=None,
-        boot_result={}, perm_result={}, perm_splithalf={}, inputs={}
+        u=None, s=None, v=None, usc=None, vsc=None, lvcorrs=None, inputs={},
+        boot_result={}, perm_result={}, perm_splithalf={}, cross_val={}
     )
 
     def __init__(self, **kwargs):
@@ -185,6 +203,7 @@ class PLSResults(utils.DefDict):
         self.boot_result = self.PLSBootResult(**self.boot_result)
         self.perm_result = self.PLSPermResult(**self.perm_result)
         self.perm_splithalf = self.PLSSplitHalfResult(**self.perm_splithalf)
+        self.cross_val = self.PLSCrossValidationResults(**self.cross_val)
 
 
 class BasePLS():

--- a/pyls/compute.py
+++ b/pyls/compute.py
@@ -30,26 +30,6 @@ def rescale_test(X_train, X_test, Y_train, U, V):
     return Y_pred
 
 
-def get_cv(true, pred):
-    """
-    Generates the determination coefficient (delta CV or R^2)
-
-    Parameters
-    ----------
-    true : (S x T) array_like
-        True values
-    pred : (S x T) array_like
-        Predicted values
-
-    Returns
-    -------
-    r2 : float
-        Relative distance between predicted and true values
-    """
-
-    return 1 - (np.sum((true - pred)**2) / np.sum((true - true.mean())**2))
-
-
 def perm_sig(orig, perm):
     """
     Calculates significance of ``orig`` values agains ``perm`` distributions

--- a/pyls/compute.py
+++ b/pyls/compute.py
@@ -5,39 +5,6 @@ from sklearn.utils.extmath import randomized_svd
 from pyls import utils
 
 
-def zscore_comp(data, comp, axis=0, ddof=1):
-    """
-    Uses ``distribution`` to z-score ``data`` along ``axis``
-
-    Useful for z-scoring patient populations relative to healthy controls
-
-    Parameters
-    ----------
-    data : (N x ...) array_like
-        Data to be z-scored
-    comp : (M x ...) array_like
-        Distribution to z-score ``data``. Should have same dimension as data
-        along `axis`
-    axis : int, optional
-        Axis to use to z-score data. Default: 0
-    ddof : int, optional
-        Delta degrees of freedom.  The divisor used in calculations is
-        ``M - ddof``, where ``M`` is the number of elements along ``axis``
-        in ``comp``. Default: 1
-
-    Returns
-    -------
-    zscored : np.ndarray
-        Z-scored version of ``data``
-    """
-
-    dmean = np.asarray(comp).mean(axis=axis, keepdims=True)
-    dstd = np.asarray(comp).std(axis=axis, ddof=ddof, keepdims=True)
-    zscored = (np.asarray(data) - dmean) / dstd
-
-    return zscored
-
-
 def rescale_test(X_train, X_test, Y_train, U, V):
     """
     Generates out-of-sample predicted ``Y`` values
@@ -57,7 +24,7 @@ def rescale_test(X_train, X_test, Y_train, U, V):
         Behavioral matrix, where ``S2`` is observations and ``T`` is features
     """
 
-    X_resc = zscore_comp(X_test, comp=X_train, axis=0, ddof=1)
+    X_resc = utils.zscore(X_test, comp=X_train, axis=0, ddof=1)
     Y_test = X_resc @ U @ V.T + Y_train.mean(axis=0, keepdims=True)
 
     return Y_test
@@ -65,7 +32,7 @@ def rescale_test(X_train, X_test, Y_train, U, V):
 
 def get_cv(true, pred):
     """
-    Generates the cross-validated determination coefficient (delta CV, R^2)
+    Generates the determination coefficient (delta CV or R^2)
 
     Parameters
     ----------

--- a/pyls/compute.py
+++ b/pyls/compute.py
@@ -20,14 +20,14 @@ def rescale_test(X_train, X_test, Y_train, U, V):
 
     Returns
     -------
-    Y_test : (S2 x T) np.ndarray
+    Y_pred : (S2 x T) np.ndarray
         Behavioral matrix, where ``S2`` is observations and ``T`` is features
     """
 
     X_resc = utils.zscore(X_test, comp=X_train, axis=0, ddof=1)
-    Y_test = X_resc @ U @ V.T + Y_train.mean(axis=0, keepdims=True)
+    Y_pred = (X_resc @ U @ V.T) + Y_train.mean(axis=0, keepdims=True)
 
-    return Y_test
+    return Y_pred
 
 
 def get_cv(true, pred):
@@ -47,7 +47,7 @@ def get_cv(true, pred):
         Relative distance between predicted and true values
     """
 
-    return 1 - (np.sum((true - pred)**2) / np.sum((true - true.mean()**2)))
+    return 1 - (np.sum((true - pred)**2) / np.sum((true - true.mean())**2))
 
 
 def perm_sig(orig, perm):

--- a/pyls/tests/test_base.py
+++ b/pyls/tests/test_base.py
@@ -34,6 +34,9 @@ def test_PLSInputs():
 
     assert pyls.base.PLSInputs(n_split=0).n_split is None
 
+    with pytest.raises(ValueError):
+        pyls.base.PLSInputs(test_size=1)
+
 
 def test_BasePLS():
     basepls = pyls.base.BasePLS(**opts)

--- a/pyls/tests/test_types.py
+++ b/pyls/tests/test_types.py
@@ -37,8 +37,9 @@ class PLSBaseTest():
 
         Returns
         -------
-        attrs : list
-            Expected attributes and shapes
+        attrs : list-of-tuples
+            Each entry in the list is a tuple with the attribute name and
+            expected shape
         """
 
         dummy = len(self.output.inputs.groups) * self.output.inputs.n_cond
@@ -60,46 +61,37 @@ class PLSBaseTest():
         return attrs
 
     def confirm_outputs(self):
-        """
-        Used to confirm ``output`` has expected ``attributes```
-
-        Parameters
-        ----------
-        output : PLS output
-        attributes : list-of-tuple
-            From output of ``make_outputs()``
-        """
-        attributes = self.make_outputs()
-        for (attr, shape) in attributes:
+        """ Confirms generated outputs are of expected shape / size """
+        for (attr, shape) in self.make_outputs():
             assert hasattr(self.output, attr)
             assert getattr(self.output, attr).shape == shape
 
 
-def test_BehavioralPLS_onegroup_onecond():
+def test_BehavioralPLS_onegroup_onecondition():
     kwargs = dict(groups=None, n_cond=1)
     for (ns, rt) in itertools.product([None, 5], [True, False]):
         PLSBaseTest('behavioral', n_split=ns, rotate=rt, **kwargs)
 
 
-def test_BehavioralPLS_multigroup_onecond():
+def test_BehavioralPLS_multigroup_onecondition():
     kwargs = dict(groups=[33, 34, 33], n_cond=1)
     for (ns, rt) in itertools.product([None, 5], [True, False]):
         PLSBaseTest('behavioral', n_split=ns, rotate=rt, **kwargs)
 
 
-def test_BehavioralPLS_onegroup_multicond():
+def test_BehavioralPLS_onegroup_multicondition():
     kwargs = dict(groups=subj // 4, n_cond=4)
     for (ns, rt) in itertools.product([None, 5], [True, False]):
         PLSBaseTest('behavioral', n_split=ns, rotate=rt, **kwargs)
 
 
-def test_BehavioralPLS_multigroup_multicond():
+def test_BehavioralPLS_multigroup_multicondition():
     kwargs = dict(groups=[25, 25], n_cond=2)
     for (ns, rt) in itertools.product([None, 5], [True, False]):
         PLSBaseTest('behavioral', n_split=ns, rotate=rt, **kwargs)
 
 
-def test_MeanCenteredPLS_multigroup_onecond():
+def test_MeanCenteredPLS_multigroup_onecondition():
     kwargs = dict(groups=[33, 34, 33], n_cond=1)
     for (mc, ns, rt) in itertools.product([1, 2], [None, 5], [True, False]):
         PLSBaseTest('meancentered', n_split=ns, mean_centering=mc, rotate=rt,
@@ -108,7 +100,7 @@ def test_MeanCenteredPLS_multigroup_onecond():
         PLSBaseTest('meancentered', groups=[50, 50], mean_centering=0)
 
 
-def test_MeanCenteredPLS_onegroup_multicond():
+def test_MeanCenteredPLS_onegroup_multicondition():
     kwargs = dict(groups=[subj // 2], n_cond=2)
     for (mc, ns, rt) in itertools.product([0, 2], [None, 5], [True, False]):
         PLSBaseTest('meancentered', n_split=ns, mean_centering=mc, rotate=rt,
@@ -117,7 +109,7 @@ def test_MeanCenteredPLS_onegroup_multicond():
         PLSBaseTest('meancentered', mean_centering=1, **kwargs)
 
 
-def test_MeanCenteredPLS_multigroup_multicond():
+def test_MeanCenteredPLS_multigroup_multicondition():
     kwargs = dict(groups=[25, 25], n_cond=2)
     for (mc, ns, rt) in itertools.product([0, 1, 2], [None, 5], [True, False]):
         PLSBaseTest('meancentered', n_split=ns, mean_centering=mc, rotate=rt,

--- a/pyls/tests/test_utils.py
+++ b/pyls/tests/test_utils.py
@@ -57,9 +57,3 @@ def test_dummycode():
 
     dummy_cond = pyls.utils.dummy_code(groups, n_cond=3)
     assert dummy_cond.shape == (np.sum(groups) * 3, len(groups) * 3)
-
-
-def test_get_seed():
-    pyls.utils.get_seed()
-    pyls.utils.get_seed(1234)
-    pyls.utils.get_seed(rs)

--- a/pyls/types.py
+++ b/pyls/types.py
@@ -3,7 +3,6 @@
 import warnings
 import numpy as np
 from sklearn.metrics import r2_score
-from sklearn.model_selection import train_test_split
 from pyls.base import BasePLS
 from pyls import compute, utils
 
@@ -18,7 +17,8 @@ class BehavioralPLS(BasePLS):
     between ``groups``. Permutation testing is used to examine statistical
     significance and split-half resampling is used to assess reliability of
     LVs. Bootstrap resampling is used to examine reliability of features (K)
-    across LVs.
+    across LVs. A cross-validated framework is used to examine the predictive
+    accuracy of the decomposition.
 
     Parameters
     ----------
@@ -140,26 +140,43 @@ class BehavioralPLS(BasePLS):
 
         Returns
         -------
+        r_scores : (C,) np.ndarray
+            R (Pearon correlation) scores across train-test splits
         r2_scores : (C,) np.ndarray
             R^2 (coefficient of determination) scores across train-test splits
         """
 
-        r2_scores = np.zeros(self.inputs.n_split)
+        # use gen_splits to handle grouping/condition vars in train/test split
         splits = self.gen_splits(test_size=self.inputs.test_size)
         dummy = utils.dummy_code(self.inputs.groups, self.inputs.n_cond)
+        r_scores = np.zeros((Y.shape[-1], self.inputs.n_split))
+        r2_scores = np.zeros((Y.shape[-1], self.inputs.n_split))
 
         for i in utils.trange(self.inputs.n_split, desc='Running cross-val'):
+            # subset appropriately into train/test sets
             split = splits[:, i]
             X_train, Y_train, dummy_train = X[split], Y[split], dummy[split]
-            X_test, Y_test = X[~split], Y[~split]
-
+            X_test, Y_test, dummy_test = X[~split], Y[~split], dummy[~split]
+            # perform initial decomposition on train set
             U, d, V = self.svd(X_train, Y_train,
                                dummy=dummy_train,
                                seed=self.rs)
-            Y_pred = compute.rescale_test(X_train, X_test, Y_train, U, V)
-            r2_scores[i] = r2_score(Y_test, Y_pred)
+            # rescale test set prediction, handling grouping/condition vars
+            Y_pred = np.row_stack([compute.rescale_test(X_train[tr_grp],
+                                                        X_test[te_grp],
+                                                        Y_train[tr_grp],
+                                                        U, V_spl)
+                                   for V_spl, tr_grp, te_grp in
+                                   zip(np.split(V, dummy.shape[-1]),
+                                       dummy_train.T.astype(bool),
+                                       dummy_test.T.astype(bool))])
+            # calculate r & r-squared from comp of rescaled test & true values
+            r_scores[:, i] = [np.corrcoef(Y_test[:, i], Y_pred[:, i])[0, 1]
+                              for i in range(Y_test.shape[-1])]
+            r2_scores[:, i] = r2_score(Y_test, Y_pred,
+                                       multioutput='raw_values')
 
-        return r2_scores
+        return r_scores, r2_scores
 
     def run_pls(self, X, Y):
         """
@@ -203,8 +220,9 @@ class BehavioralPLS(BasePLS):
                                     llcorr=llcorr, ulcorr=ulcorr))
 
         # compute cross-validated coefficient of determination
-        if (self.inputs.n_split is not None) and self.inputs.test_size > 0:
-            self.r2 = self.crossval(X, Y)
+        if self.inputs.n_split is not None and self.inputs.test_size > 0:
+            r, r2 = self.crossval(X, Y)
+            res.cross_val.update(dict(pearson_r=r, r_squared=r2))
 
         return res
 

--- a/pyls/utils.py
+++ b/pyls/utils.py
@@ -190,21 +190,32 @@ def dummy_code(groups, n_cond=1):
         Dummy-coded group array
     """
 
-    length = sum(groups) * n_cond
-    width = len(groups) * n_cond
-    Y = np.zeros((length, width))
-    cstart = 0  # starting index for columns
-    rstart = 0  # starting index for rows
+    labels = dummy_label(groups, n_cond)
+    dummy = np.column_stack([labels == g for g in np.unique(labels)])
 
-    for i, grp in enumerate(groups):
-        vals = np.repeat(np.eye(n_cond), grp).reshape(
-            (n_cond, n_cond * grp)).T
-        Y[:, cstart:cstart + n_cond][rstart:rstart + (grp * n_cond)] = vals
+    return dummy.astype(int)
 
-        cstart += vals.shape[1]
-        rstart += vals.shape[0]
 
-    return Y
+def dummy_label(groups, n_cond=1):
+    """
+    Generates group labels for ``groups`` and ``n_cond``
+
+    Parameters
+    ----------
+    groups : (G,) list
+        List with number of subjects in each of ``G`` groups
+    n_cond : int, optional
+        Number of conditions, for each subject. Default: 1
+
+    Returns
+    -------
+    Y : (S,) np.ndarray
+        Dummy-label group array
+    """
+
+    num_labels = len(groups * n_cond)
+
+    return np.repeat(np.arange(num_labels) + 1, np.repeat(groups, n_cond))
 
 
 def permute_cols(x, seed=None):

--- a/pyls/utils.py
+++ b/pyls/utils.py
@@ -64,8 +64,8 @@ def trange(n_iter, **kwargs):
     """
 
     form = '{desc}: {percentage:3.0f}%|{bar}| {n_fmt}/{total_fmt}'
-    return tqdm.trange(n_iter, ascii=True, leave=False,
-                       bar_format=form, **kwargs)
+    return tqdm.trange(n_iter, ascii=True, leave=False, bar_format=form,
+                       **kwargs)
 
 
 def xcorr(X, Y, norm=True):

--- a/pyls/utils.py
+++ b/pyls/utils.py
@@ -2,6 +2,7 @@
 
 import numpy as np
 import tqdm
+from sklearn.utils.validation import check_array, check_random_state
 
 
 class DefDict(dict):
@@ -93,7 +94,7 @@ def xcorr(X, Y, norm=True):
     return xprod
 
 
-def zscore(X):
+def zscore(data, axis=0, ddof=1, comp=None):
     """
     Z-scores ``X`` by subtracting mean and dividing by standard deviation
 
@@ -102,23 +103,41 @@ def zscore(X):
 
     Parameters
     ----------
-    X : (S x B) array_like
-        Input array
+    data : (N x ...) array_like
+        Data to be z-scored
+    axis : int, optional
+        Axis to use to z-score data. Default: 0
+    ddof : int, optional
+        Delta degrees of freedom.  The divisor used in calculations is
+        ``M - ddof``, where ``M`` is the number of elements along ``axis``
+        in ``comp``. Default: 1
+    comp : (M x ...) array_like
+        Distribution to z-score ``data``. Should have same dimension as data
+        along `axis`. Default: ``data``
 
     Returns
     -------
-    zarr : (S x B) np.ndarray
-        Z-scored ``X``
+    zarr : (N x ...) np.ndarray
+        Z-scored version of ``data``
     """
 
-    arr = np.array(X)
-    avg, stdev = arr.mean(axis=0), arr.std(axis=0, ddof=1)
-    zero_items = np.where(stdev == 0)[0]
+    data = check_array(data, ensure_2d=False, allow_nd=True)
 
-    if zero_items.size > 0:
-        avg[zero_items], stdev[zero_items] = 0, 1
-    zarr = (arr - avg) / stdev
-    zarr[:, zero_items] = 0
+    if comp is not None:
+        comp = check_array(comp, ensure_2d=False, allow_nd=True)
+    else:
+        comp = data
+
+    avg = comp.mean(axis=axis, keepdims=True)
+    stdev = comp.std(axis=axis, ddof=ddof, keepdims=True)
+    zeros = stdev == 0
+
+    if np.any(zeros):
+        avg[zeros] = 0
+        stdev[zeros] = 1
+
+    zarr = (data - avg) / stdev
+    zarr[np.repeat(zeros, zarr.shape[axis], axis=axis)] = 0
 
     return zarr
 
@@ -154,32 +173,6 @@ def normalize(X, axis=0):
     return normed
 
 
-def get_seed(seed=None):
-    """
-    Determines type of ``seed`` and returns RandomState instance
-
-    Parameters
-    ----------
-    seed : {int, RandomState instance, None}, optional
-        The seed of the pseudo random number generator to use when shuffling
-        the data.  If int, ``seed`` is the seed used by the random number
-        generator. If RandomState instance, ``seed`` is the random number
-        generator. If None, the random number generator is the RandomState
-        instance used by ``np.random``. Default: None
-
-    Returns
-    -------
-    RandomState instance
-    """
-
-    if seed is not None:
-        if isinstance(seed, int):
-            return np.random.RandomState(seed)
-        elif isinstance(seed, np.random.RandomState):
-            return seed
-    return np.random
-
-
 def dummy_code(groups, n_cond=1):
     """
     Dummy codes ``groups`` and ``n_cond``
@@ -193,7 +186,7 @@ def dummy_code(groups, n_cond=1):
 
     Returns
     -------
-    Y : (S x G*C) np.ndarray
+    Y : (S x F) np.ndarray
         Dummy-coded group array
     """
 
@@ -218,7 +211,7 @@ def permute_cols(x, seed=None):
     """
     Permutes the rows for each column in ``x`` separately
 
-    Taken directly from https://stackoverflow.com/a/27489131
+    Taken from https://stackoverflow.com/a/27489131
 
     Parameters
     ----------
@@ -233,7 +226,7 @@ def permute_cols(x, seed=None):
         Permuted array
     """
 
-    rs = get_seed(seed)
+    rs = check_random_state(seed)
     ix_i = rs.random_sample(x.shape).argsort(axis=0)
     ix_j = np.tile(np.arange(x.shape[1]), (x.shape[0], 1))
     return x[ix_i, ix_j]


### PR DESCRIPTION
Closes #21.

This PR adds cross-validation (CV), as described in [Rahim et al., 2017](http://ieeexplore.ieee.org/document/7981504/), to `BehavioralPLS`. Briefly, CV splits input data into train/test sets, performs a PLS decomposition on the train set, uses the singular vectors from the decomposition to generate predicted behavior scores in the test set, and compares predicted with true (test) behavior scores. This CV operation generates (1) Pearson's correlations and (2) R-squared metrics of true + predicted scores for each behavioral metric.

A new input argument `test_split` has been added to `BehavioralPLS` to determine the train/test split ratio. The number of splits is determined by the `n_split` argument. CV results can be found in the generated results structure under `results.cross_val.pearson_r` and `results.cross_val.r_squared`, respectively.