### PR TITLE
[REF] Moves utils.py functions to compute.py

### DIFF
--- a/pyls/compute.py
+++ b/pyls/compute.py
@@ -2,7 +2,121 @@
 
 import numpy as np
 from sklearn.utils.extmath import randomized_svd
+from sklearn.utils.validation import check_array
 from pyls import utils
+
+
+def xcorr(X, Y, norm=True):
+    """
+    Calculates the cross-covariance matrix of `X` and `Y`
+
+    Parameters
+    ----------
+    X : (S, B) array_like
+        Input matrix, where `S` is samples and `B` is features.
+    Y : (S, T) array_like, optional
+        Input matrix, where `S` is samples and `T` is features.
+
+    Returns
+    -------
+    xprod : (T, B) `numpy.ndarray`
+        Cross-covariance of `X` and `Y`
+    """
+
+    if X.ndim != Y.ndim:
+        raise ValueError('Number of dims of `X` and `Y` must match.')
+    if X.ndim != 2:
+        raise ValueError('`X` and `Y` must each have 2 dims.')
+    if len(X) != len(Y):
+        raise ValueError('The first dim of `X` and `Y` must match.')
+
+    Xn, Yn = zscore(X), zscore(Y)
+    if norm:
+        Xn, Yn = normalize(Xn), normalize(Yn)
+    xprod = (Yn.T @ Xn) / (len(Xn) - 1)
+
+    return xprod
+
+
+def zscore(data, axis=0, ddof=1, comp=None):
+    """
+    Z-scores `X` by subtracting mean and dividing by standard deviation
+
+    Effectively the same as `np.nan_to_num(scipy.stats.zscore(X))` but
+    handles DivideByZero without issuing annoying warnings.
+
+    Parameters
+    ----------
+    data : (N, ...) array_like
+        Data to be z-scored
+    axis : int, optional
+        Axis to use to z-score data. Default: 0
+    ddof : int, optional
+        Delta degrees of freedom.  The divisor used in calculations is
+        `M - ddof`, where `M` is the number of elements along `axis` in
+        `comp`. Default: 1
+    comp : (M, ...) array_like
+        Distribution to z-score `data`. Should have same dimension as data
+        along `axis`. Default: `data`
+
+    Returns
+    -------
+    zarr : (N, ...) `numpy.ndarray`
+        Z-scored version of `data`
+    """
+
+    data = check_array(data, ensure_2d=False, allow_nd=True)
+
+    # check if z-score against another distribution or self
+    if comp is not None:
+        comp = check_array(comp, ensure_2d=False, allow_nd=True)
+    else:
+        comp = data
+
+    avg = comp.mean(axis=axis, keepdims=True)
+    stdev = comp.std(axis=axis, ddof=ddof, keepdims=True)
+    zeros = stdev == 0
+    # avoid DivideByZero errors
+    if np.any(zeros):
+        avg[zeros] = 0
+        stdev[zeros] = 1
+
+    zarr = (data - avg) / stdev
+    zarr[np.repeat(zeros, zarr.shape[axis], axis=axis)] = 0
+
+    return zarr
+
+
+def normalize(X, axis=0):
+    """
+    Normalizes `X` along `axis`
+
+    Utilizes Frobenius norm (or Hilbert-Schmidt norm / `L_{p,q}` norm where
+    `p=q=2`)
+
+    Parameters
+    ----------
+    X : (S, B) array_like
+        Input array
+    axis : int, optional
+        Axis for normalization. Default: 0
+
+    Returns
+    -------
+    normed : (S, B) `numpy.ndarray`
+        Normalized `X`
+    """
+
+    normed = np.array(X)
+    normal_base = np.linalg.norm(normed, axis=axis, keepdims=True)
+    # avoid DivideByZero errors
+    zero_items = np.where(normal_base == 0)
+    normal_base[zero_items] = 1
+    # normalize and re-set zero_items to 0
+    normed = normed / normal_base
+    normed[zero_items] = 0
+
+    return normed
 
 
 def rescale_test(X_train, X_test, Y_train, U, V):
@@ -24,7 +138,7 @@ def rescale_test(X_train, X_test, Y_train, U, V):
         Behavioral matrix, where `S2` is observations and `T` is features
     """
 
-    X_resc = utils.zscore(X_test, comp=X_train, axis=0, ddof=1)
+    X_resc = zscore(X_test, comp=X_train, axis=0, ddof=1)
     Y_pred = (X_resc @ U @ V.T) + Y_train.mean(axis=0, keepdims=True)
 
     return Y_pred

--- a/pyls/tests/test_compute.py
+++ b/pyls/tests/test_compute.py
@@ -1,0 +1,42 @@
+# -*- coding: utf-8 -*-
+
+import numpy as np
+import pytest
+import pyls
+
+rs = np.random.RandomState(1234)
+
+
+def test_zscore():
+    out = pyls.compute.zscore([[1]] * 10)
+    assert np.allclose(out, 0)
+
+    out = pyls.compute.zscore(rs.rand(10, 10))
+    assert out.shape == (10, 10)
+    assert not np.allclose(out, 0)
+
+
+def test_normalize():
+    X = rs.rand(10, 10)
+    out = pyls.compute.normalize(X, axis=0)
+    assert np.allclose(np.sum(out**2, axis=0), 1)
+
+    out = pyls.compute.normalize(X, axis=1)
+    assert np.allclose(np.sum(out**2, axis=1), 1)
+
+
+def test_xcorr():
+    X = rs.rand(20, 200)
+    Y = rs.rand(20, 25)
+
+    xcorr = pyls.compute.xcorr(X, Y)
+    assert xcorr.shape == (25, 200)
+    xcorr = pyls.compute.xcorr(X, Y, norm=False)
+    assert xcorr.shape == (25, 200)
+
+    with pytest.raises(ValueError):
+        pyls.compute.xcorr(X[:, 0], Y)
+    with pytest.raises(ValueError):
+        pyls.compute.xcorr(X[:, 0], Y[:, 0])
+    with pytest.raises(ValueError):
+        pyls.compute.xcorr(X[0:10], Y)

--- a/pyls/tests/test_utils.py
+++ b/pyls/tests/test_utils.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 
 import numpy as np
-import pytest
 import pyls
 
 rs = np.random.RandomState(1234)
@@ -15,41 +14,6 @@ def test_RefDict():
     assert str(d) == 'ResDict()'
     assert(str(BlahDict(test={})) == 'BlahDict()')
     assert(str(BlahDict(test=10)) == 'BlahDict(test)')
-
-
-def test_zscore():
-    out = pyls.utils.zscore([[1]] * 10)
-    assert np.allclose(out, 0)
-
-    out = pyls.utils.zscore(rs.rand(10, 10))
-    assert out.shape == (10, 10)
-    assert not np.allclose(out, 0)
-
-
-def test_normalize():
-    X = rs.rand(10, 10)
-    out = pyls.utils.normalize(X, axis=0)
-    assert np.allclose(np.sum(out**2, axis=0), 1)
-
-    out = pyls.utils.normalize(X, axis=1)
-    assert np.allclose(np.sum(out**2, axis=1), 1)
-
-
-def test_xcorr():
-    X = rs.rand(20, 200)
-    Y = rs.rand(20, 25)
-
-    xcorr = pyls.utils.xcorr(X, Y)
-    assert xcorr.shape == (25, 200)
-    xcorr = pyls.utils.xcorr(X, Y, norm=False)
-    assert xcorr.shape == (25, 200)
-
-    with pytest.raises(ValueError):
-        pyls.utils.xcorr(X[:, 0], Y)
-    with pytest.raises(ValueError):
-        pyls.utils.xcorr(X[:, 0], Y[:, 0])
-    with pytest.raises(ValueError):
-        pyls.utils.xcorr(X[0:10], Y)
 
 
 def test_dummycode():

--- a/pyls/types.py
+++ b/pyls/types.py
@@ -43,7 +43,7 @@ class BehavioralPLS(BasePLS):
             Cross-covariance matrix
         """
 
-        crosscov = np.row_stack([utils.xcorr(X[grp], Y[grp], norm=False)
+        crosscov = np.row_stack([compute.xcorr(X[grp], Y[grp], norm=False)
                                  for grp in groups.T.astype(bool)])
 
         return crosscov
@@ -78,7 +78,7 @@ class BehavioralPLS(BasePLS):
 
         for i in utils.trange(self.inputs.n_boot, desc='Calculating CI'):
             boot = self.bootsamp[:, i]
-            tusc = X[boot] @ utils.normalize(U_boot[:, :, i])
+            tusc = X[boot] @ compute.normalize(U_boot[:, :, i])
             distrib[:, :, i] = self.gen_covcorr(tusc, Y[boot], groups)
 
         return distrib
@@ -334,7 +334,7 @@ class MeanCenteredPLS(BasePLS):
             usc = compute.get_mean_center(X[boot], Y,
                                           self.inputs.n_cond,
                                           self.inputs.mean_centering,
-                                          means=False) @ utils.normalize(U)
+                                          means=False) @ compute.normalize(U)
             distrib[:, :, i] = np.row_stack([usc[grp].mean(axis=0) for grp
                                              in Y.T.astype(bool)])
 

--- a/pyls/utils.py
+++ b/pyls/utils.py
@@ -3,7 +3,7 @@
 import numpy as np
 import tqdm
 from sklearn.utils import Bunch
-from sklearn.utils.validation import check_array, check_random_state
+from sklearn.utils.validation import check_random_state
 
 
 class ResDict(Bunch):
@@ -76,119 +76,6 @@ def trange(n_iter, **kwargs):
     defaults.update(kwargs)
 
     return tqdm.trange(n_iter, **defaults)
-
-
-def xcorr(X, Y, norm=True):
-    """
-    Calculates the cross-covariance matrix of `X` and `Y`
-
-    Parameters
-    ----------
-    X : (S, B) array_like
-        Input matrix, where `S` is samples and `B` is features.
-    Y : (S, T) array_like, optional
-        Input matrix, where `S` is samples and `T` is features.
-
-    Returns
-    -------
-    xprod : (T, B) `numpy.ndarray`
-        Cross-covariance of `X` and `Y`
-    """
-
-    if X.ndim != Y.ndim:
-        raise ValueError('Number of dims of `X` and `Y` must match.')
-    if X.ndim != 2:
-        raise ValueError('`X` and `Y` must each have 2 dims.')
-    if len(X) != len(Y):
-        raise ValueError('The first dim of `X` and `Y` must match.')
-
-    Xn, Yn = zscore(X), zscore(Y)
-    if norm:
-        Xn, Yn = normalize(Xn), normalize(Yn)
-    xprod = (Yn.T @ Xn) / (len(Xn) - 1)
-
-    return xprod
-
-
-def zscore(data, axis=0, ddof=1, comp=None):
-    """
-    Z-scores `X` by subtracting mean and dividing by standard deviation
-
-    Effectively the same as `np.nan_to_num(scipy.stats.zscore(X))` but
-    handles DivideByZero without issuing annoying warnings.
-
-    Parameters
-    ----------
-    data : (N, ...) array_like
-        Data to be z-scored
-    axis : int, optional
-        Axis to use to z-score data. Default: 0
-    ddof : int, optional
-        Delta degrees of freedom.  The divisor used in calculations is
-        `M - ddof`, where `M` is the number of elements along `axis` in
-        `comp`. Default: 1
-    comp : (M, ...) array_like
-        Distribution to z-score `data`. Should have same dimension as data
-        along `axis`. Default: `data`
-
-    Returns
-    -------
-    zarr : (N, ...) `numpy.ndarray`
-        Z-scored version of `data`
-    """
-
-    data = check_array(data, ensure_2d=False, allow_nd=True)
-
-    # check if z-score against another distribution or self
-    if comp is not None:
-        comp = check_array(comp, ensure_2d=False, allow_nd=True)
-    else:
-        comp = data
-
-    avg = comp.mean(axis=axis, keepdims=True)
-    stdev = comp.std(axis=axis, ddof=ddof, keepdims=True)
-    zeros = stdev == 0
-    # avoid DivideByZero errors
-    if np.any(zeros):
-        avg[zeros] = 0
-        stdev[zeros] = 1
-
-    zarr = (data - avg) / stdev
-    zarr[np.repeat(zeros, zarr.shape[axis], axis=axis)] = 0
-
-    return zarr
-
-
-def normalize(X, axis=0):
-    """
-    Normalizes `X` along `axis`
-
-    Utilizes Frobenius norm (or Hilbert-Schmidt norm / `L_{p,q}` norm where
-    `p=q=2`)
-
-    Parameters
-    ----------
-    X : (S, B) array_like
-        Input array
-    axis : int, optional
-        Axis for normalization. Default: 0
-
-    Returns
-    -------
-    normed : (S, B) `numpy.ndarray`
-        Normalized `X`
-    """
-
-    normed = np.array(X)
-    normal_base = np.linalg.norm(normed, axis=axis, keepdims=True)
-    # avoid DivideByZero errors
-    zero_items = np.where(normal_base == 0)
-    normal_base[zero_items] = 1
-    # normalize and re-set zero_items to 0
-    normed = normed / normal_base
-    normed[zero_items] = 0
-
-    return normed
 
 
 def dummy_code(groups, n_cond=1):


### PR DESCRIPTION
Moves xcorr, zscore, and normalize from utils.py to compute.py. These functions are all more heavily used in computations throughout the module than they are used as "utilities". Minor change, but makes more sense that they be colocated with similar functions.