### PR TITLE
[ENH] Adds option for covariance decomposition

### DIFF
--- a/pyls/compute.py
+++ b/pyls/compute.py
@@ -6,7 +6,7 @@ from sklearn.utils.validation import check_array
 from pyls import utils
 
 
-def xcorr(X, Y, norm=True):
+def xcorr(X, Y, norm=True, covariance=False):
     """
     Calculates the cross-covariance matrix of `X` and `Y`
 
@@ -16,6 +16,12 @@ def xcorr(X, Y, norm=True):
         Input matrix, where `S` is samples and `B` is features.
     Y : (S, T) array_like, optional
         Input matrix, where `S` is samples and `T` is features.
+    norm : bool, optional
+        Whether to normalize `X` and `Y` (i.e., sum of squares = 1). Default:
+        True
+    covariance : bool, optional
+        Whether to calculate the cross-covariance matrix instead of the cross-
+        correlation matrix. Default: False
 
     Returns
     -------
@@ -30,7 +36,11 @@ def xcorr(X, Y, norm=True):
     if len(X) != len(Y):
         raise ValueError('The first dim of `X` and `Y` must match.')
 
-    Xn, Yn = zscore(X), zscore(Y)
+    if not covariance:
+        Xn, Yn = zscore(X), zscore(Y)
+    else:
+        Xn, Yn = X - X.mean(0, keepdims=True), Y - Y.mean(0, keepdims=True)
+
     if norm:
         Xn, Yn = normalize(Xn), normalize(Yn)
     xprod = (Yn.T @ Xn) / (len(Xn) - 1)

--- a/pyls/structures.py
+++ b/pyls/structures.py
@@ -60,6 +60,14 @@ _pls_input_docs = dict(
         Proportion of data to partition to test set during cross-validation.
         Default: 0.25\
     """),
+    covariance=dedent("""\
+    covariance : bool, optional
+        Whether to use the cross-covariance matrix instead of the cross-
+        correlation during the decomposition. Only set if you are sure this is
+        what you want as many of the results may become more difficult to
+        interpret (i.e., :py:attr:`~.structures.PLSResults.behavcorr` will no
+        longer be intepretable as Pearson correlation r values). Default: False
+    """),
     rotate=dedent("""\
     rotate : bool, optional
         Whether to perform Procrustes rotations during permutation testing. Can
@@ -109,13 +117,13 @@ _pls_input_docs = dict(
 class PLSInputs(ResDict):
     allowed = [
         'X', 'Y', 'groups', 'n_cond', 'n_perm', 'n_boot', 'n_split',
-        'test_size', 'mean_centering', 'rotate', 'ci', 'seed',
+        'test_size', 'mean_centering', 'covariance', 'rotate', 'ci', 'seed',
         'bootsamples', 'permsamples', 'verbose'
     ]
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        if self.get('n_split', 0) == 0:
+        if self.get('n_split', None) == 0:
             self['n_split'] = None
         ts = self.get('test_size', None)
         if ts is not None and (ts < 0 or ts >= 1):

--- a/pyls/types/behavioral.py
+++ b/pyls/types/behavioral.py
@@ -8,15 +8,15 @@ from .. import compute, utils
 
 
 class BehavioralPLS(BasePLS):
-    def __init__(self, X, Y, *, groups=None, n_cond=1, mean_centering=0,
-                 n_perm=5000, n_boot=5000, n_split=100, test_size=0.25,
+    def __init__(self, X, Y, *, groups=None, n_cond=1, n_perm=5000,
+                 n_boot=5000, n_split=100, test_size=0.25, covariance=False,
                  rotate=True, ci=95, seed=None, verbose=True, **kwargs):
 
         super().__init__(X=np.asarray(X), Y=np.asarray(Y), groups=groups,
-                         n_cond=n_cond, mean_centering=mean_centering,
-                         n_perm=n_perm, n_boot=n_boot, n_split=n_split,
-                         test_size=test_size, rotate=rotate, ci=ci, seed=seed,
-                         verbose=verbose, **kwargs)
+                         n_cond=n_cond, n_perm=n_perm, n_boot=n_boot,
+                         n_split=n_split, test_size=test_size,
+                         covariance=covariance, rotate=rotate, ci=ci,
+                         seed=seed, verbose=verbose, **kwargs)
         self.results = self.run_pls(self.inputs.X, self.inputs.Y)
 
     def gen_covcorr(self, X, Y, groups, **kwargs):
@@ -41,10 +41,13 @@ class BehavioralPLS(BasePLS):
             Cross-covariance matrix
         """
 
-        crosscov = np.row_stack([compute.xcorr(X[grp], Y[grp], norm=False)
-                                 for grp in groups.T.astype(bool)])
+        crosscov = []
+        for grp in groups.T.astype(bool):
+            crosscov.append(compute.xcorr(X[grp], Y[grp],
+                                          norm=False,
+                                          covariance=self.inputs.covariance))
 
-        return crosscov
+        return np.row_stack(crosscov)
 
     def boot_distrib(self, X, Y, U_boot, groups):
         """
@@ -190,14 +193,14 @@ class BehavioralPLS(BasePLS):
 
 
 # let's make it a function
-def behavioral_pls(X, Y, *, groups=None, n_cond=1, mean_centering=0,
-                   n_perm=5000, n_boot=5000, n_split=100, test_size=0.25,
-                   rotate=True, ci=95, seed=None, verbose=True, **kwargs):
+def behavioral_pls(X, Y, *, groups=None, n_cond=1, n_perm=5000, n_boot=5000,
+                   n_split=100, test_size=0.25, covariance=False, rotate=True,
+                   ci=95, seed=None, verbose=True, **kwargs):
     pls = BehavioralPLS(X=X, Y=Y, groups=groups, n_cond=n_cond,
-                        mean_centering=mean_centering,
                         n_perm=n_perm, n_boot=n_boot, n_split=n_split,
-                        test_size=test_size, rotate=rotate, ci=ci, seed=seed,
-                        verbose=verbose, **kwargs)
+                        test_size=test_size, covariance=covariance,
+                        rotate=rotate, ci=ci, seed=seed, verbose=verbose,
+                        **kwargs)
     return pls.results
 
 
@@ -225,6 +228,7 @@ Y : (S, T) array_like
 {groups}
 {conditions}
 {stat_test}
+{covariance}
 {rotate}
 {ci}
 {seed}


### PR DESCRIPTION
The default option is still to decompose the cross-correlation matrix of the provided `X` and `Y` matrices, but now users can optionally specify that they would like to decompose the cross-covariance matrix.