### PR TITLE
[ENH] Adds support for parallel permutations/bootstraps

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ env:
   matrix:
     - LINTING=1
     - DOCTEST=1
+    - JOBLIB=1
 
 matrix:
   include:
@@ -37,6 +38,9 @@ before_install:
     fi
   - if [ "${COVERAGE}" == "1" ]; then
         pip install coverage coveralls codecov;
+    fi
+  - if [ "${JOBLIB}" == "1" ]; then
+        pip install joblib;
     fi
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ matrix:
   - python: 3.6
     env:
       - COVERAGE=1
+      - JOBLIB=1
   - python: 3.7
     dist: xenial
     sudo: required

--- a/pyls/__init__.py
+++ b/pyls/__init__.py
@@ -4,7 +4,7 @@ __all__ = [
     '__author__', '__description__', '__email__', '__license__',
     '__maintainer__', '__packagename__', '__url__', '__version__',
     'behavioral_pls', 'meancentered_pls', 'import_matlab_result',
-    'PLSResults', 'save_results', 'load_results'
+    'PLSInputs', 'PLSResults', 'save_results', 'load_results'
 ]
 
 from ._version import get_versions
@@ -23,5 +23,5 @@ from .info import (
 
 from .io import load_results, save_results
 from .matlab import import_matlab_result
-from .structures import PLSResults
+from .structures import PLSInputs, PLSResults
 from .types import (behavioral_pls, meancentered_pls)

--- a/pyls/base.py
+++ b/pyls/base.py
@@ -250,7 +250,7 @@ class BasePLS():
     ----------
     {input_matrix}
     {groups}
-    {n_cond}
+    {conditions}
     **kwargs : optional
         Additional key-value pairs; see :obj:`pyls.PLSInputs` for more info
 

--- a/pyls/base.py
+++ b/pyls/base.py
@@ -46,7 +46,6 @@ def gen_permsamp(groups, n_cond, n_perm, seed=None, verbose=True):
     splitinds = np.cumsum(groups)[:-1]
     check_grps = utils.dummy_code(groups).T.astype(bool)
 
-    # can only use tqdm progress bar if not parallel processing
     for i in utils.trange(n_perm, verbose=verbose, desc='Making permutations'):
         count, duplicated = 0, True
         while duplicated and count < 500:

--- a/pyls/base.py
+++ b/pyls/base.py
@@ -248,14 +248,11 @@ class BasePLS():
 
     Parameters
     ----------
-    X : (S, B) array_like
-        Input data matrix, where `S` is observations and `B` is features
-    groups : (G,) array_like, optional
-        Array with number of subjects in each of `G` groups. Default: `[S]`
-    n_cond : int, optional
-        Number of conditions. Default: 1
+    {input_matrix}
+    {groups}
+    {n_cond}
     **kwargs : optional
-        See `pyls.base.PLSInputs` for more information
+        Additional key-value pairs; see :obj:`pyls.PLSInputs` for more info
 
     References
     ----------

--- a/pyls/structures.py
+++ b/pyls/structures.py
@@ -56,7 +56,7 @@ _pls_input_docs = dict(
     n_split : int, optional
         Number of split-half resamples to assess during permutation testing.
         This also controls the number of train/test splits examined during
-        cross-validation if :attr:`test_size` is not zero. Default: 100
+        cross-validation if :attr:`test_size` is not zero. Default: 100\
     """),
     cross_val=dedent("""\
     test_split : int, optional
@@ -72,7 +72,7 @@ _pls_input_docs = dict(
         correlation during the decomposition. Only set if you are sure this is
         what you want as many of the results may become more difficult to
         interpret (i.e., :py:attr:`~.structures.PLSResults.behavcorr` will no
-        longer be intepretable as Pearson correlation r values). Default: False
+        longer be intepretable as Pearson correlation values). Default: False\
     """),
     rotate=dedent("""\
     rotate : bool, optional
@@ -89,13 +89,15 @@ _pls_input_docs = dict(
     proc_options=dedent("""\
     seed : {int, :obj:`numpy.random.RandomState`, None}, optional
         Seed to use for random number generation. Helps ensure reproducibility
-        of results. Default: None\
+        of results. Default: None
     verbose : bool, optional
-        Whether to print status messages about the progress of the PLS analysis
-        as it progresses. Default: True
+        Whether to show progress bars as the analysis runs. Note that progress
+        bars will not persist after the analysis is completed. Default: True
     n_proc : int, optional
         How many processes to use for parallelizing permutation testing and
-        bootstrap resampling.
+        bootstrap resampling. If not specified will default to serialized
+        processing (i.e., one processor). Can optionally specify 'max' to use
+        all available processors. Default: None\
     """),
     pls_results=dedent("""\
     results : :obj:`pyls.PLSResults`
@@ -132,10 +134,13 @@ class PLSInputs(ResDict):
         super().__init__(*args, **kwargs)
         if self.get('n_split') == 0:
             self['n_split'] = None
+
         if self.get('test_split') == 0:
             self['test_split'] = None
+
         if self.get('n_proc') == 'max':
             self['n_proc'] = cpu_count()
+
         ts = self.get('test_size')
         if ts is not None and (ts < 0 or ts >= 1):
             raise ValueError('test_size must be in [0, 1). Provided value: {}'

--- a/pyls/structures.py
+++ b/pyls/structures.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+from multiprocessing import cpu_count
 from textwrap import dedent
 from .utils import ResDict
 
@@ -80,15 +81,16 @@ _pls_input_docs = dict(
         roughly corresponds to an alpha rate; e.g., the 95%ile CI is
         approximately equivalent to a two-tailed p <= 0.05. Default: 95\
     """),
-    seed=dedent("""\
+    proc_options=dedent("""\
     seed : {int, :obj:`numpy.random.RandomState`, None}, optional
         Seed to use for random number generation. Helps ensure reproducibility
         of results. Default: None\
-    """),
-    verbose=dedent("""\
     verbose : bool, optional
         Whether to print status messages about the progress of the PLS analysis
         as it progresses. Default: True
+    n_proc : int, optional
+        How many processes to use for parallelizing permutation testing and
+        bootstrap resampling.
     """),
     pls_results=dedent("""\
     results : :obj:`pyls.PLSResults`
@@ -118,13 +120,15 @@ class PLSInputs(ResDict):
     allowed = [
         'X', 'Y', 'groups', 'n_cond', 'n_perm', 'n_boot', 'n_split',
         'test_size', 'mean_centering', 'covariance', 'rotate', 'ci', 'seed',
-        'bootsamples', 'permsamples', 'verbose'
+        'bootsamples', 'permsamples', 'verbose', 'n_proc'
     ]
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         if self.get('n_split', None) == 0:
             self['n_split'] = None
+        if self.get('n_proc', None) == 'max':
+            self['n_proc'] = cpu_count()
         ts = self.get('test_size', None)
         if ts is not None and (ts < 0 or ts >= 1):
             raise ValueError('test_size must be in [0, 1). Provided value: {}'
@@ -146,11 +150,11 @@ PLSInputs.__doc__ = dedent("""\
     {groups}
     {conditions}
     {mean_centering}
+    {covariance}
     {stat_test}
     {rotate}
     {ci}
-    {seed}
-    {verbose}
+    {proc_options}
     """).format(**_pls_input_docs)
 
 

--- a/pyls/structures.py
+++ b/pyls/structures.py
@@ -57,6 +57,11 @@ _pls_input_docs = dict(
         Number of split-half resamples to assess during permutation testing.
         This also controls the number of train/test splits examined during
         cross-validation if :attr:`test_size` is not zero. Default: 100
+    """),
+    cross_val=dedent("""\
+    test_split : int, optional
+        Number of splits for generating test sets during cross-validation.
+        Default: 100
     test_size : [0, 1) float, optional
         Proportion of data to partition to test set during cross-validation.
         Default: 0.25\
@@ -119,18 +124,18 @@ _pls_input_docs = dict(
 class PLSInputs(ResDict):
     allowed = [
         'X', 'Y', 'groups', 'n_cond', 'n_perm', 'n_boot', 'n_split',
-        'test_size', 'mean_centering', 'covariance', 'rotate', 'ci', 'seed',
-        'bootsamples', 'permsamples', 'verbose', 'n_proc'
+        'test_split', 'test_size', 'mean_centering', 'covariance', 'rotate',
+        'ci', 'seed', 'verbose', 'n_proc', 'bootsamples', 'permsamples'
     ]
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         if self.get('n_split') == 0:
             self['n_split'] = None
+        if self.get('test_split') == 0:
+            self['test_split'] = None
         if self.get('n_proc') == 'max':
             self['n_proc'] = cpu_count()
-        elif self.get('n_proc') is None:
-            self['n_proc'] = 1
         ts = self.get('test_size')
         if ts is not None and (ts < 0 or ts >= 1):
             raise ValueError('test_size must be in [0, 1). Provided value: {}'

--- a/pyls/structures.py
+++ b/pyls/structures.py
@@ -125,11 +125,13 @@ class PLSInputs(ResDict):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        if self.get('n_split', None) == 0:
+        if self.get('n_split') == 0:
             self['n_split'] = None
-        if self.get('n_proc', None) == 'max':
+        if self.get('n_proc') == 'max':
             self['n_proc'] = cpu_count()
-        ts = self.get('test_size', None)
+        elif self.get('n_proc') is None:
+            self['n_proc'] = 1
+        ts = self.get('test_size')
         if ts is not None and (ts < 0 or ts >= 1):
             raise ValueError('test_size must be in [0, 1). Provided value: {}'
                              .format(ts))

--- a/pyls/tests/test_base.py
+++ b/pyls/tests/test_base.py
@@ -48,3 +48,6 @@ def test_BasePLS():
 
     with pytest.raises(NotImplementedError):
         basepls.gen_covcorr(X, Y, groups)
+    with pytest.raises(ValueError):
+        opts['groups'] = [100, 100]
+        basepls = pyls.base.BasePLS(**opts)

--- a/pyls/tests/test_types.py
+++ b/pyls/tests/test_types.py
@@ -67,31 +67,31 @@ class PLSBaseTest():
             assert getattr(self.output, attr).shape == shape
 
 
-def test_BehavioralPLS_onegroup_onecondition():
+def test_behavioral_onegroup_onecondition():
     kwargs = dict(groups=None, n_cond=1)
     for (ns, rt) in itertools.product([None, 5], [True, False]):
         PLSBaseTest('behavioral', n_split=ns, rotate=rt, **kwargs)
 
 
-def test_BehavioralPLS_multigroup_onecondition():
+def test_behavioral_multigroup_onecondition():
     kwargs = dict(groups=[33, 34, 33], n_cond=1)
     for (ns, rt) in itertools.product([None, 5], [True, False]):
         PLSBaseTest('behavioral', n_split=ns, rotate=rt, **kwargs)
 
 
-def test_BehavioralPLS_onegroup_multicondition():
+def test_behavioral_onegroup_multicondition():
     kwargs = dict(groups=subj // 4, n_cond=4)
     for (ns, rt) in itertools.product([None, 5], [True, False]):
         PLSBaseTest('behavioral', n_split=ns, rotate=rt, **kwargs)
 
 
-def test_BehavioralPLS_multigroup_multicondition():
+def test_behavioral_multigroup_multicondition():
     kwargs = dict(groups=[25, 25], n_cond=2)
     for (ns, rt) in itertools.product([None, 5], [True, False]):
         PLSBaseTest('behavioral', n_split=ns, rotate=rt, **kwargs)
 
 
-def test_MeanCenteredPLS_multigroup_onecondition():
+def test_meancentered_multigroup_onecondition():
     kwargs = dict(groups=[33, 34, 33], n_cond=1)
     for (mc, ns, rt) in itertools.product([1, 2], [None, 5], [True, False]):
         PLSBaseTest('meancentered', n_split=ns, mean_centering=mc, rotate=rt,
@@ -100,8 +100,8 @@ def test_MeanCenteredPLS_multigroup_onecondition():
         PLSBaseTest('meancentered', groups=[50, 50], mean_centering=0)
 
 
-def test_MeanCenteredPLS_onegroup_multicondition():
-    kwargs = dict(n_cond=2)
+def test_meancentered_onegroup_multicondition():
+    kwargs = dict(groups=subj // 2, n_cond=2)
     for (mc, ns, rt) in itertools.product([0, 2], [None, 5], [True, False]):
         PLSBaseTest('meancentered', n_split=ns, mean_centering=mc, rotate=rt,
                     **kwargs)
@@ -109,7 +109,7 @@ def test_MeanCenteredPLS_onegroup_multicondition():
         PLSBaseTest('meancentered', mean_centering=1, **kwargs)
 
 
-def test_MeanCenteredPLS_multigroup_multicondition():
+def test_meancentered_multigroup_multicondition():
     kwargs = dict(groups=[25, 25], n_cond=2)
     for (mc, ns, rt) in itertools.product([0, 1, 2], [None, 5], [True, False]):
         PLSBaseTest('meancentered', n_split=ns, mean_centering=mc, rotate=rt,
@@ -121,3 +121,7 @@ def test_errors():
         PLSBaseTest('meancentered', groups=[50, 50], mean_centering=3)
     with pytest.raises(ValueError):
         PLSBaseTest('meancentered', groups=[subj])
+    with pytest.raises(ValueError):
+        PLSBaseTest('meancentered', n_cond=3)
+    with pytest.raises(ValueError):
+        PLSBaseTest('behavioral', Y=rs.rand(subj - 1, Yf))

--- a/pyls/tests/test_utils.py
+++ b/pyls/tests/test_utils.py
@@ -1,28 +1,152 @@
 # -*- coding: utf-8 -*-
 
 import numpy as np
-import pyls
+from pyls import utils
+import pytest
+import tqdm
 
-rs = np.random.RandomState(1234)
+
+def test_empty_dict():
+    assert utils._empty_dict({})
+    assert utils._empty_dict(dict())
+    assert not utils._empty_dict(dict(d=10))
+    assert not utils._empty_dict(dict(d=dict(d=dict(d=10))))
+    assert not utils._empty_dict([])
+    assert not utils._empty_dict(None)
+    assert not utils._empty_dict('test')
+    assert not utils._empty_dict(10)
+    assert not utils._empty_dict(10.0)
+    assert not utils._empty_dict(set())
 
 
-def test_RefDict():
-    class BlahDict(pyls.utils.ResDict):
-        allowed = ['test']
+def test_not_empty_keys():
+    assert utils._not_empty_keys(dict()) == set()
+    assert utils._not_empty_keys(dict(test=10)) == {'test'}
+    assert utils._not_empty_keys(dict(test=10, temp=None)) == {'test'}
+    assert utils._not_empty_keys(dict(test=10, temp={})) == {'test'}
 
-    d = pyls.utils.ResDict()
+    with pytest.raises(TypeError):
+        utils._not_empty_keys([10, 20, 30])
+
+
+def test_ResDict():
+    # toy example with some allowed keys
+    class TestDict(utils.ResDict):
+        allowed = ['test', 'temp']
+
+    # confirm string representations work
+    d = utils.ResDict()
     assert str(d) == 'ResDict()'
-    assert(str(BlahDict(test={})) == 'BlahDict()')
-    assert(str(BlahDict(test=10)) == 'BlahDict(test)')
+    assert str(TestDict(test={})) == 'TestDict()'
+    assert str(TestDict(test=None)) == 'TestDict()'
+    assert d != TestDict()
+
+    # confirm general key checking works
+    test1 = TestDict(test=10)
+    test2 = TestDict(test=11)
+    test3 = TestDict(test=10, temp=11)
+    assert str(test1) == 'TestDict(test)'
+    assert str(test2) == 'TestDict(test)'
+    assert str(test3) == 'TestDict(test, temp)'
+    assert test1 == test1
+    assert test1 != test2
+    assert test1 != test3
+
+    # confirm numpy array comparisons work
+    test1 = TestDict(test=np.arange(9))
+    test2 = TestDict(test=np.arange(9) + 1e-6)  # should work
+    test3 = TestDict(test=np.arange(9) + 1e-5)  # too high
+    test4 = TestDict(test=np.arange(10))  # totally different
+    assert test1 == test1
+    assert test1 == test2
+    assert test1 != test3
+    assert test1 != test4
+
+    # confirm nested dictionary comparisons work
+    test1 = TestDict(test=test1)
+    test2 = TestDict(test=test3)
+    assert test1 == test1
+    assert test1 != test2
+
+    # confirm item assignment holds
+    test1.temp = 10
+    assert test1.temp == 10
+    assert test1 == test1
+    assert test1 != test2
+
+    # confirm rejection of item assignment not in cls.allowed
+    test1.blargh = 10
+    assert not hasattr(test1, 'blargh')
+
+    test1.temp = None
+    test2.temp = None
+    assert test1 != test2
 
 
-def test_dummycode():
+def test_trange():
+    # test that verbose=False generates a range object
+    out = utils.trange(1000, verbose=False, desc='Test tqdm')
+    assert out == range(1000)
+    # test that function will accept arbitrary kwargs and overwrite defaults
+    out = utils.trange(1000, desc='Test tqdm', mininterval=0.5, ascii=False)
+    assert isinstance(out, tqdm.tqdm)
+
+
+def test_dummy_label():
     groups = [10, 12, 11]
-    dummy = pyls.utils.dummy_code(groups)
-    assert dummy.shape == (np.sum(groups), len(groups))
+    expected = [[10, 12, 11], [10, 10, 12, 12, 11, 11]]
+    for n_cond in range(1, 3):
+        dummy = utils.dummy_label(groups, n_cond=n_cond)
+        assert dummy.shape == (np.sum(groups) * n_cond,)
+        assert np.unique(dummy).size == len(groups) * n_cond
+        for n, grp in enumerate(np.unique(dummy)):
+            assert np.sum(dummy == grp) == expected[n_cond - 1][n]
 
-    for n, grp in enumerate(dummy.T.astype(bool)):
-        assert grp.sum() == groups[n]
 
-    dummy_cond = pyls.utils.dummy_code(groups, n_cond=3)
-    assert dummy_cond.shape == (np.sum(groups) * 3, len(groups) * 3)
+def test_dummy_code():
+    groups = [10, 12, 11]
+    expected = [[10, 12, 11], [10, 10, 12, 12, 11, 11]]
+    for n_cond in range(1, 3):
+        dummy = utils.dummy_code(groups, n_cond=n_cond)
+        assert dummy.shape == (np.sum(groups) * n_cond, len(groups) * n_cond)
+        assert np.all(np.unique(dummy) == [0, 1])
+        for n, grp in enumerate(dummy.T):
+            assert grp.sum() == expected[n_cond - 1][n]
+
+
+def test_permute_cols():
+    x = np.arange(9).reshape(3, 3)
+    expected = np.array([[0, 1, 5], [6, 4, 2], [3, 7, 8]])
+
+    out = utils.permute_cols(x, seed=np.random.RandomState(1234))
+    assert not np.all(out == x) and np.all(out == expected)
+
+    # don't accept 1D arrays
+    with pytest.raises(ValueError):
+        utils.permute_cols(np.arange(9))
+    # don't accept array with single row
+    with pytest.raises(ValueError):
+        utils.permute_cols(np.arange(9).reshape(1, -1))
+
+
+def test_unravel():
+    expected = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+    assert utils._unravel(range(10)) == expected
+    expected = [0, 1, 4, 9, 16, 25, 36, 49, 64, 81]
+    assert utils._unravel(x ** 2 for x in range(10)) == expected
+
+
+def test_get_par_func():
+    def fcn(x):
+        return x
+
+    if not utils.joblib_avail:
+        par, func = utils.get_par_func(1000, fcn)
+        assert par == utils._unravel
+        assert fcn == func
+    else:
+        import joblib
+        par, func = utils.get_par_func(1000, fcn)
+        assert isinstance(par, joblib.Parallel)
+        assert par.n_jobs == 1000
+        assert not fcn == func

--- a/pyls/tests/test_utils.py
+++ b/pyls/tests/test_utils.py
@@ -124,9 +124,6 @@ def test_permute_cols():
     # don't accept 1D arrays
     with pytest.raises(ValueError):
         utils.permute_cols(np.arange(9))
-    # don't accept array with single row
-    with pytest.raises(ValueError):
-        utils.permute_cols(np.arange(9).reshape(1, -1))
 
 
 def test_unravel():

--- a/pyls/types/behavioral.py
+++ b/pyls/types/behavioral.py
@@ -11,7 +11,7 @@ class BehavioralPLS(BasePLS):
     def __init__(self, X, Y, *, groups=None, n_cond=1, n_perm=5000,
                  n_boot=5000, n_split=100, test_size=0.25, test_split=100,
                  covariance=False, rotate=True, ci=95, seed=None, verbose=True,
-                 n_proc=1, **kwargs):
+                 n_proc=None, **kwargs):
 
         # check that inputs are valid
         if len(X) != len(Y):
@@ -259,7 +259,7 @@ class BehavioralPLS(BasePLS):
 def behavioral_pls(X, Y, *, groups=None, n_cond=1, n_perm=5000, n_boot=5000,
                    n_split=100, test_size=0.25, test_split=100,
                    covariance=False, rotate=True, ci=95, seed=None,
-                   verbose=True, n_proc=1, **kwargs):
+                   verbose=True, n_proc=None, **kwargs):
     pls = BehavioralPLS(X=X, Y=Y, groups=groups, n_cond=n_cond,
                         n_perm=n_perm, n_boot=n_boot, n_split=n_split,
                         test_size=test_size, test_split=test_split,

--- a/pyls/types/behavioral.py
+++ b/pyls/types/behavioral.py
@@ -10,13 +10,14 @@ from .. import compute, utils
 class BehavioralPLS(BasePLS):
     def __init__(self, X, Y, *, groups=None, n_cond=1, n_perm=5000,
                  n_boot=5000, n_split=100, test_size=0.25, covariance=False,
-                 rotate=True, ci=95, seed=None, verbose=True, **kwargs):
+                 rotate=True, ci=95, seed=None, verbose=True, n_proc=1,
+                 **kwargs):
 
         super().__init__(X=np.asarray(X), Y=np.asarray(Y), groups=groups,
                          n_cond=n_cond, n_perm=n_perm, n_boot=n_boot,
                          n_split=n_split, test_size=test_size,
                          covariance=covariance, rotate=rotate, ci=ci,
-                         seed=seed, verbose=verbose, **kwargs)
+                         seed=seed, verbose=verbose, n_proc=n_proc, **kwargs)
         self.results = self.run_pls(self.inputs.X, self.inputs.Y)
 
     def gen_covcorr(self, X, Y, groups, **kwargs):
@@ -195,12 +196,12 @@ class BehavioralPLS(BasePLS):
 # let's make it a function
 def behavioral_pls(X, Y, *, groups=None, n_cond=1, n_perm=5000, n_boot=5000,
                    n_split=100, test_size=0.25, covariance=False, rotate=True,
-                   ci=95, seed=None, verbose=True, **kwargs):
+                   ci=95, seed=None, verbose=True, n_proc=1, **kwargs):
     pls = BehavioralPLS(X=X, Y=Y, groups=groups, n_cond=n_cond,
                         n_perm=n_perm, n_boot=n_boot, n_split=n_split,
                         test_size=test_size, covariance=covariance,
                         rotate=rotate, ci=ci, seed=seed, verbose=verbose,
-                        **kwargs)
+                        n_proc=n_proc, **kwargs)
     return pls.results
 
 
@@ -231,8 +232,7 @@ Y : (S, T) array_like
 {covariance}
 {rotate}
 {ci}
-{seed}
-{verbose}
+{proc_options}
 
 Returns
 ----------

--- a/pyls/types/behavioral.py
+++ b/pyls/types/behavioral.py
@@ -9,15 +9,23 @@ from .. import compute, utils
 
 class BehavioralPLS(BasePLS):
     def __init__(self, X, Y, *, groups=None, n_cond=1, n_perm=5000,
-                 n_boot=5000, n_split=100, test_size=0.25, covariance=False,
-                 rotate=True, ci=95, seed=None, verbose=True, n_proc=1,
-                 **kwargs):
+                 n_boot=5000, n_split=100, test_size=0.25, test_split=100,
+                 covariance=False, rotate=True, ci=95, seed=None, verbose=True,
+                 n_proc=1, **kwargs):
+
+        # check that inputs are valid
+        if len(X) != len(Y):
+            raise ValueError('Provided `X` and `Y` matrices must have the '
+                             'same number of samples. Provided matrices '
+                             'differed: X: {}, Y: {}'.format(len(X), len(Y)))
 
         super().__init__(X=np.asarray(X), Y=np.asarray(Y), groups=groups,
                          n_cond=n_cond, n_perm=n_perm, n_boot=n_boot,
                          n_split=n_split, test_size=test_size,
-                         covariance=covariance, rotate=rotate, ci=ci,
-                         seed=seed, verbose=verbose, n_proc=n_proc, **kwargs)
+                         test_split=test_split, covariance=covariance,
+                         rotate=rotate, ci=ci, seed=seed, verbose=verbose,
+                         n_proc=n_proc, **kwargs)
+
         self.results = self.run_pls(self.inputs.X, self.inputs.Y)
 
     def gen_covcorr(self, X, Y, groups, **kwargs):
@@ -50,9 +58,9 @@ class BehavioralPLS(BasePLS):
 
         return np.row_stack(crosscov)
 
-    def boot_distrib(self, X, Y, U_boot, groups):
+    def boot_distrib(self, X, Y, U_boot, groups, verbose=True):
         """
-        Generates bootstrapped distribution for contrast
+        Generates bootstrapped distribution for behavioral correlations
 
         Parameters
         ----------
@@ -61,31 +69,62 @@ class BehavioralPLS(BasePLS):
         Y : (S, T) array_like
             Input data matrix, where `S` is observations and `T` is features
         U_boot : (K, L, B) array_like
-            Bootstrapped values of the right singular vectors, where `L` is the
+            Bootstrapped values of the left singular vectors, where `L` is the
             number of latent variables and `B` is the number of bootstraps
         groups : (S, J) array_like
             Dummy coded input array, where `S` is observations and `J`
             corresponds to the number of different groups x conditions. A value
             of 1 indicates that an observation belongs to a specific group or
             condition.
+        verbose : bool, optional
+            Whether to print status updates as CI is calculated. Default: True
 
         Returns
         -------
         distrib : (G, L, B) np.ndarray
         """
 
-        distrib = np.zeros(shape=(groups.shape[-1] * Y.shape[-1],
-                                  U_boot.shape[1],
-                                  self.inputs.n_boot,))
+        parallel, func = utils.get_par_func(self.inputs.n_proc,
+                                            self.__class__._single_distrib)
+        generator = utils.trange(self.inputs.n_boot, verbose=verbose,
+                                 desc='Calculating CI')
+        out = parallel(func(self, X=X, Y=Y, groups=groups,
+                            inds=self.bootsamp[:, i],
+                            original=U_boot[..., i]) for i in generator)
 
-        for i in utils.trange(self.inputs.n_boot, desc='Calculating CI'):
-            boot = self.bootsamp[:, i]
-            tusc = X[boot] @ compute.normalize(U_boot[:, :, i])
-            distrib[:, :, i] = self.gen_covcorr(tusc, Y[boot], groups)
+        return np.stack(out, axis=-1)
 
-        return distrib
+    def _single_distrib(self, X, Y, groups, inds, original):
+        """
+        Finds behavioral correlations for single bootstrap resample
 
-    def crossval(self, X, Y):
+        Parameters
+        ----------
+        X : (S, B) array_like
+            Input data matrix, where `S` is observations and `B` is features
+        Y : (S, T) array_like
+            Input data matrix, where `S` is observations and `T` is features
+        groups : (S, J) array_like
+            Dummy coded input array, where `S` is observations and `J`
+            corresponds to the number of different groups x conditions. A value
+            of 1 indicates that an observation belongs to a specific group or
+            condition.
+        inds : (S,) array_like
+            Bootstrap resampling array
+        boot : (B, L) array_like
+            Left singular vectors from bootstrap
+
+        Returns
+        -------
+        distrib : (T, L)
+            Behavioral correlations for single bootstrap resample
+        """
+
+        tusc = X[inds] @ compute.normalize(original)
+
+        return self.gen_covcorr(tusc, Y[inds], groups)
+
+    def crossval(self, X, Y, seed=None, verbose=True):
         """
         Performs cross-validation of SVD of `X` and `Y`
 
@@ -95,6 +134,10 @@ class BehavioralPLS(BasePLS):
             Input data matrix, where `S` is observations and `B` is features
         Y : (S, T) array_like
             Input data matrix, where `S` is observations and `T` is features
+        seed : {int, :obj:`numpy.random.RandomState`, None}, optional
+            Seed for random number generation. Default: None
+        verbose : bool, optional
+            Whether to print status updates as CV is calculated. Default: True
 
         Returns
         -------
@@ -107,36 +150,53 @@ class BehavioralPLS(BasePLS):
         # use gen_splits to handle grouping/condition vars in train/test split
         splits = gen_splits(self.inputs.groups,
                             self.inputs.n_cond,
-                            self.inputs.n_split,
-                            seed=self.rs,
+                            self.inputs.test_split,
+                            seed=seed,
                             test_size=self.inputs.test_size)
         dummy = utils.dummy_code(self.inputs.groups, self.inputs.n_cond)
-        r_scores = np.zeros((Y.shape[-1], self.inputs.n_split))
-        r2_scores = np.zeros((Y.shape[-1], self.inputs.n_split))
 
-        for i in utils.trange(self.inputs.n_split, desc='Running cross-val'):
-            # subset appropriately into train/test sets
-            split = splits[:, i]
-            X_train, Y_train, dummy_train = X[split], Y[split], dummy[split]
-            X_test, Y_test, dummy_test = X[~split], Y[~split], dummy[~split]
-            # perform initial decomposition on train set
-            U, d, V = self.svd(X_train, Y_train,
-                               dummy=dummy_train,
-                               seed=self.rs)
-            # rescale test set prediction, handling grouping/condition vars
-            Y_pred = np.row_stack([compute.rescale_test(X_train[tr_grp],
-                                                        X_test[te_grp],
-                                                        Y_train[tr_grp],
-                                                        U, V_spl)
-                                   for V_spl, tr_grp, te_grp in
-                                   zip(np.split(V, dummy.shape[-1]),
-                                       dummy_train.T.astype(bool),
-                                       dummy_test.T.astype(bool))])
-            # calculate r & r-squared from comp of rescaled test & true values
-            r_scores[:, i] = [np.corrcoef(Y_test[:, i], Y_pred[:, i])[0, 1]
-                              for i in range(Y_test.shape[-1])]
-            r2_scores[:, i] = r2_score(Y_test, Y_pred,
-                                       multioutput='raw_values')
+        parallel, func = utils.get_par_func(self.inputs.n_proc,
+                                            self.__class__._single_crossval)
+        generator = utils.trange(self.inputs.test_split, verbose=verbose,
+                                 desc='Running cross-validation')
+        out = parallel(func(self, X=X, Y=Y, dummy=dummy,
+                            inds=splits[:, i], seed=i) for i in generator)
+        r_scores, r2_scores = [np.stack(o, axis=-1) for o in zip(*out)]
+
+        return r_scores, r2_scores
+
+    def _single_crossval(self, X, Y, dummy, inds, seed=None):
+        """
+        Generates single cross-validated r and r^2 score
+
+        Parameters
+        ----------
+        X : (S, B) array_like
+            Input data matrix, where `S` is observations and `B` is features
+        Y : (S, T) array_like
+            Input data matrix, where `S` is observations and `T` is features
+        seed : {int, :obj:`numpy.random.RandomState`, None}, optional
+            Seed for random number generation. Default: None
+        """
+
+        X_train, Y_train, dummy_train = X[inds], Y[inds], dummy[inds]
+        X_test, Y_test, dummy_test = X[~inds], Y[~inds], dummy[~inds]
+        # perform initial decomposition on train set
+        U, d, V = self.svd(X_train, Y_train, dummy=dummy_train, seed=seed)
+
+        # rescale the test set based on the training set
+        Y_pred = []
+        for n, V_spl in enumerate(np.split(V, dummy.shape[-1])):
+            tr_grp = dummy_train[:, n].astype(bool)
+            te_grp = dummy_test[:, n].astype(bool)
+            rescaled = compute.rescale_test(X_train[tr_grp], X_test[te_grp],
+                                            Y_train[tr_grp], U, V_spl)
+            Y_pred.append(rescaled)
+        Y_pred = np.row_stack(Y_pred)
+
+        # calculate r & r-squared from comp of rescaled test & true values
+        r_scores = compute.efficient_corr(Y_test, Y_pred)
+        r2_scores = r2_score(Y_test, Y_pred, multioutput='raw_values')
 
         return r_scores, r2_scores
 
@@ -166,11 +226,12 @@ class BehavioralPLS(BasePLS):
 
         # compute bootstraps and BSRs
         if self.inputs.n_boot > 0:
-            U_boot, V_boot = self.bootstrap(X, Y)
+            U_boot, V_boot = self.bootstrap(X, Y, seed=self.rs)
             compare_u, u_se = compute.boot_rel(res.u @ res.s, U_boot)
 
             # generate distribution / confidence intervals for lvcorrs
-            distrib = self.boot_distrib(X, Y, U_boot, groups)
+            distrib = self.boot_distrib(X, Y, U_boot, groups,
+                                        verbose=self.inputs.verbose)
             llcorr, ulcorr = compute.boot_ci(distrib, ci=self.inputs.ci)
 
             # update results.boot_result dictionary
@@ -183,8 +244,9 @@ class BehavioralPLS(BasePLS):
                                     behavcorr_uplim=ulcorr))
 
         # compute cross-validated prediction-based metrics
-        if self.inputs.n_split is not None and self.inputs.test_size > 0:
-            r, r2 = self.crossval(X, Y)
+        if self.inputs.test_split is not None and self.inputs.test_size > 0:
+            r, r2 = self.crossval(X, Y, seed=self.rs,
+                                  verbose=self.inputs.verbose)
             res.cvres.update(dict(pearson_r=r, r_squared=r2))
 
         # get rid of the stupid diagonal matrix
@@ -195,13 +257,14 @@ class BehavioralPLS(BasePLS):
 
 # let's make it a function
 def behavioral_pls(X, Y, *, groups=None, n_cond=1, n_perm=5000, n_boot=5000,
-                   n_split=100, test_size=0.25, covariance=False, rotate=True,
-                   ci=95, seed=None, verbose=True, n_proc=1, **kwargs):
+                   n_split=100, test_size=0.25, test_split=100,
+                   covariance=False, rotate=True, ci=95, seed=None,
+                   verbose=True, n_proc=1, **kwargs):
     pls = BehavioralPLS(X=X, Y=Y, groups=groups, n_cond=n_cond,
                         n_perm=n_perm, n_boot=n_boot, n_split=n_split,
-                        test_size=test_size, covariance=covariance,
-                        rotate=rotate, ci=ci, seed=seed, verbose=verbose,
-                        n_proc=n_proc, **kwargs)
+                        test_size=test_size, test_split=test_split,
+                        covariance=covariance, rotate=rotate, ci=ci, seed=seed,
+                        verbose=verbose, n_proc=n_proc, **kwargs)
     return pls.results
 
 
@@ -229,6 +292,7 @@ Y : (S, T) array_like
 {groups}
 {conditions}
 {stat_test}
+{cross_val}
 {covariance}
 {rotate}
 {ci}

--- a/pyls/types/meancentered.py
+++ b/pyls/types/meancentered.py
@@ -10,7 +10,7 @@ from .. import compute, utils
 class MeanCenteredPLS(BasePLS):
     def __init__(self, X, groups=None, n_cond=1, mean_centering=0, n_perm=5000,
                  n_boot=5000, n_split=100, test_size=0.25, rotate=True, ci=95,
-                 seed=None, verbose=True, **kwargs):
+                 seed=None, verbose=True, n_proc=1, **kwargs):
         if groups is None:
             groups = [len(X) // n_cond]
         # check inputs for validity
@@ -31,7 +31,7 @@ class MeanCenteredPLS(BasePLS):
                          mean_centering=mean_centering, n_perm=n_perm,
                          n_boot=n_boot, n_split=n_split, test_size=test_size,
                          rotate=rotate, ci=ci, seed=seed, verbose=verbose,
-                         **kwargs)
+                         n_proc=n_proc, **kwargs)
         self.inputs.Y = utils.dummy_code(self.inputs.groups,
                                          self.inputs.n_cond)
         self.results = self.run_pls(self.inputs.X, self.inputs.Y)
@@ -153,12 +153,13 @@ class MeanCenteredPLS(BasePLS):
 
 def meancentered_pls(X, *, groups=None, n_cond=1, mean_centering=0,
                      n_perm=5000, n_boot=5000, n_split=100, test_size=0.25,
-                     rotate=True, ci=95, seed=None, verbose=True, **kwargs):
+                     rotate=True, ci=95, seed=None, verbose=True, n_proc=1,
+                     **kwargs):
     pls = MeanCenteredPLS(X=X, groups=groups, n_cond=n_cond,
                           mean_centering=mean_centering,
                           n_perm=n_perm, n_boot=n_boot, n_split=n_split,
                           test_size=test_size, rotate=rotate, ci=ci, seed=seed,
-                          verbose=verbose, **kwargs)
+                          verbose=verbose, n_proc=n_proc, **kwargs)
     return pls.results
 
 
@@ -186,8 +187,7 @@ Parameters
 {stat_test}
 {rotate}
 {ci}
-{seed}
-{verbose}
+{proc_options}
 
 Returns
 ----------

--- a/pyls/types/meancentered.py
+++ b/pyls/types/meancentered.py
@@ -11,14 +11,24 @@ class MeanCenteredPLS(BasePLS):
     def __init__(self, X, groups=None, n_cond=1, mean_centering=0, n_perm=5000,
                  n_boot=5000, n_split=100, test_size=0.25, rotate=True, ci=95,
                  seed=None, verbose=True, n_proc=1, **kwargs):
+
+        # check that groups and conditions are set appropriately
         if groups is None:
-            groups = [len(X) // n_cond]
+            groups = [len(X) / n_cond]
+        elif not isinstance(groups, (list, np.ndarray)):
+            groups = [groups]
+        if groups[0] != int(groups[0]):
+            raise ValueError('Provided `X` matrix with {} samples is not '
+                             'evenly divisible into {} conditions. Please '
+                             'confirm inputs are correct and try again. '
+                             .format(len(X), n_cond))
+
         # check inputs for validity
         if n_cond == 1 and len(groups) == 1:
             raise ValueError('Cannot perform PLS with only one group and one '
                              'condition. Please confirm inputs are correct.')
         if n_cond == 1 and mean_centering == 0:
-            warnings.warn('Cannot set mean_centering to 0 when there is only'
+            warnings.warn('Cannot set mean_centering to 0 when there is only '
                           'one condition. Resetting mean_centering to 1.')
             mean_centering = 1
         elif len(groups) == 1 and mean_centering == 1:
@@ -62,7 +72,7 @@ class MeanCenteredPLS(BasePLS):
                                                 means=True)
         return mean_centered
 
-    def boot_distrib(self, X, Y, U_boot):
+    def boot_distrib(self, X, Y, U_boot, verbose=True):
         """
         Generates bootstrapped distribution for contrast
 
@@ -76,29 +86,55 @@ class MeanCenteredPLS(BasePLS):
             of 1 indicates that an observation belongs to a specific group or
             condition.
         U_boot : (B, L, R) array_like
-            Bootstrapped values of the right singular vectors, where `B` is the
+            Bootstrapped values of the left singular vectors, where `B` is the
             same as in `X`, `L` is the number of latent variables and `R` is
             the number of bootstraps
-
+        verbose : bool, optional
+            Whether to print status updates as CI is calculated. Default: True
 
         Returns
         -------
         distrib : (T, L, R) np.ndarray
         """
 
-        distrib = np.zeros(shape=(Y.shape[-1], U_boot.shape[1],
-                                  self.inputs.n_boot,))
+        parallel, func = utils.get_par_func(self.inputs.n_proc,
+                                            self.__class__._single_distrib)
+        generator = utils.trange(self.inputs.n_boot, verbose=verbose,
+                                 desc='Calculating CI')
+        out = parallel(func(self, X=X, Y=Y,
+                            inds=self.bootsamp[:, i],
+                            boot=U_boot[..., i]) for i in generator)
 
-        for i in utils.trange(self.inputs.n_boot, desc='Calculating CI'):
-            boot, U = self.bootsamp[:, i], U_boot[:, :, i]
-            usc = compute.get_mean_center(X[boot], Y,
-                                          self.inputs.n_cond,
-                                          self.inputs.mean_centering,
-                                          means=False) @ compute.normalize(U)
-            distrib[:, :, i] = np.row_stack([usc[grp].mean(axis=0) for grp
-                                             in Y.T.astype(bool)])
+        return np.stack(out, axis=-1)
 
-        return distrib
+    def _single_distrib(self, X, Y, inds, boot):
+        """
+        Finds contrast for single bootstrap resample
+
+        Parameters
+        ----------
+        X : (S, B) array_like
+            Input data matrix, where `S` is observations and `B` is features
+        Y : (S, T) array_like
+            Dummy coded input array, where `S` is observations and `T`
+            corresponds to the number of different groups x conditions. A value
+            of 1 indicates that an observation belongs to a specific group or
+            condition.
+        inds : (S,) array_like
+            Bootstrap resampling array
+        boot : (B, L) array_like
+            Left singular vectors from bootstrap
+
+        Returns
+        -------
+        distrib : (T, L)
+            Contrast for single bootstrap resample
+        """
+
+        usc = compute.get_mean_center(X[inds], Y, self.inputs.n_cond,
+                                      self.inputs.mean_centering, means=False)
+        usc = usc @ compute.normalize(boot)
+        return np.row_stack([usc[g].mean(axis=0) for g in Y.T.astype(bool)])
 
     def run_pls(self, X, Y):
         """
@@ -129,11 +165,12 @@ class MeanCenteredPLS(BasePLS):
 
         if self.inputs.n_boot > 0:
             # compute bootstraps and BSRs
-            U_boot, V_boot = self.bootstrap(X, Y)
+            U_boot, V_boot = self.bootstrap(X, Y, seed=self.rs)
             compare_u, u_se = compute.boot_rel(res.u @ res.s, U_boot)
 
             # generate distribution / confidence intervals for contrast
-            distrib = self.boot_distrib(X, Y, U_boot)
+            distrib = self.boot_distrib(X, Y, U_boot,
+                                        verbose=self.inputs.verbose)
             llusc, ulusc = compute.boot_ci(distrib, ci=self.inputs.ci)
 
             # update results.boot_result dictionary
@@ -196,7 +233,7 @@ Returns
 Notes
 -----
 The provided `mean_centering` argument can be changed to highlight or
-"boost" potential group / condition differences by modfiying how
+"boost" potential group / condition differences by modifying how
 :math:`R_{{mean\_centered}}` is generated:
 
 - `mean_centering=0` will remove group means collapsed across conditions,


### PR DESCRIPTION
Closes #9.

Adds ability to set `n_proc` argument to define the number of processors to use for parallel computation of permutations and bootstraps to (hypothetically) speed things up.