### PR TITLE
[FIX] Fixes bootstrapping memory error with "big data"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -85,7 +85,7 @@ jobs:
             . venv/bin/activate
             for mat in /tmp/data/matlab/bpls*mat; do
               echo "${mat}"
-              python -c "import pyls.tests; pyls.tests.assert_matlab_equivalence('${mat}', n_proc='max', n_perm=2500, n_split=250);"
+              python -c "import pyls.tests; pyls.tests.assert_matlab_equivalence('${mat}', n_proc='max', n_perm=2500, n_split=100);"
             done
 
   meancentered_pls:
@@ -110,7 +110,7 @@ jobs:
             . venv/bin/activate
             for mat in /tmp/data/matlab/mpls*mat; do
               echo "${mat}"
-              python -c "import pyls.tests; pyls.tests.assert_matlab_equivalence('${mat}', n_proc='max', n_perm=2500, n_split=100);"
+              python -c "import pyls.tests; pyls.tests.assert_matlab_equivalence('${mat}', n_proc='max', n_perm=2500, n_split=250);"
             done
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -85,7 +85,7 @@ jobs:
             . venv/bin/activate
             for mat in /tmp/data/matlab/bpls*mat; do
               echo "${mat}"
-              python -c "import pyls.tests; pyls.tests.assert_matlab_equivalence('${mat}', n_proc=2, n_perm=2500, n_split=100);"
+              python -c "import pyls.tests; pyls.tests.assert_matlab_equivalence('${mat}', n_proc='max', n_perm=2500, n_split=250);"
             done
 
   meancentered_pls:
@@ -110,7 +110,7 @@ jobs:
             . venv/bin/activate
             for mat in /tmp/data/matlab/mpls*mat; do
               echo "${mat}"
-              python -c "import pyls.tests; pyls.tests.assert_matlab_equivalence('${mat}', n_proc=2, n_perm=2500, n_split=100);"
+              python -c "import pyls.tests; pyls.tests.assert_matlab_equivalence('${mat}', n_proc='max', n_perm=2500, n_split=100);"
             done
 
 workflows:

--- a/pyls/base.py
+++ b/pyls/base.py
@@ -309,8 +309,26 @@ class BasePLS():
 
         raise NotImplementedError
 
-    def gen_distrib(self, X, Y, groups, original=None):
+    def gen_distrib(self, X, Y, groups=None, original=None):
         """
+        Should generate behavioral correlations or contrast for bootstrap
+
+        Parameters
+        ----------
+        X : (S, B) array_like
+            Input data matrix, where `S` is observations and `B` is features
+        Y : (S, T) array_like
+            Input data matrix, where `S` is observations and `T` is features
+        groups : (S, J) array_like
+            Dummy coded array, where `S` is observations and `J` corresponds to
+            the number of different groups x conditions represented in `X` and
+            `Y`. A value of 1 indicates that an observation belongs to a
+            specific group or condition
+
+        Returns
+        -------
+        distrib : (T, L)
+            Behavioral correlations or contrast for single bootstrap resample
         """
 
         raise NotImplementedError
@@ -325,8 +343,11 @@ class BasePLS():
             Input data matrix, where `S` is observations and `B` is features
         Y : (S, T) array_like
             Input data matrix, where `S` is observations and `T` is features
-        groups : (G,) array_like
-            Array with number of subjects in each of `G` groups
+
+        Returns
+        -------
+        results : :obj:`pyls.PLSResults`
+            Results of PLS (not including PLS type-specific outputs)
         """
 
         # initate results structure
@@ -380,17 +401,22 @@ class BasePLS():
             Input data matrix, where `S` is observations and `B` is features
         Y : (S, T) array_like
             Input data matrix, where `S` is observations and `T` is features
+        groups : (S, J) array_like
+            Dummy coded array, where `S` is observations and `J` corresponds to
+            the number of different groups x conditions represented in `X` and
+            `Y`. A value of 1 indicates that an observation belongs to a
+            specific group or condition
         seed : {int, :obj:`numpy.random.RandomState`, None}, optional
             Seed for random number generation. Default: None
 
         Returns
         -------
         U : (B, L) `numpy.ndarray`
-            Left singular vectors
+            Left singular vectors from singular value decomposition
         d : (L, L) `numpy.ndarray`
-            Diagonal array of singular values
+            Diagonal array of singular values from singular value decomposition
         V : (J, L) `numpy.ndarray`
-            Right singular vectors
+            Right singular vectors from singular value decomposition
         """
 
         # make dummy-coded grouping array if not provided
@@ -431,8 +457,8 @@ class BasePLS():
         Returns
         -------
         distrib : (T, L) numpy.ndarray
-            Either behavioral correlations or group/condition contrast,
-            depending on PLS type
+            Either behavioral correlations or group x condition contrast;
+            depends on PLS type
         u_sum : (B, L) numpy.ndarray
             Sum of the left singular vectors across all bootstraps
         u_square : (B, L) numpy.ndarray
@@ -465,11 +491,11 @@ class BasePLS():
         distrib = []
 
         # determine the number of bootstraps we'll run each iteration
-        boots = 0
         iters = 1 if self.inputs.n_proc is None else self.inputs.n_proc
 
         with utils.trange(self.inputs.n_boot, verbose=self.inputs.verbose,
                           desc='Running bootstraps') as gen:
+            boots = 0
             while boots < self.inputs.n_boot:
                 # determine number of bootstraps to run this round
                 # we don't want to overshoot the requested number, so make

--- a/pyls/base.py
+++ b/pyls/base.py
@@ -254,7 +254,7 @@ class BasePLS():
     def __init__(self, X, groups=None, n_cond=1, **kwargs):
         # if groups aren't provided or are provided wrong, fix them
         if groups is None:
-            groups = [len(X)]
+            groups = [len(X) // n_cond]
         elif not isinstance(groups, (list, np.ndarray)):
             groups = [groups]
 

--- a/pyls/base.py
+++ b/pyls/base.py
@@ -278,8 +278,8 @@ class BasePLS():
 
         # check for parallel processing desire
         n_proc = self.inputs.get('n_proc')
-        if n_proc is not None and n_proc > 1 and not utils.joblib_avail:
-            self.inputs.n_proc = 1
+        if n_proc is not None and n_proc != 1 and not utils.joblib_avail:
+            self.inputs.n_proc = None
             warnings.warn('Setting n_proc > 1 requires the joblib module. '
                           'Considering installing joblib and re-running this '
                           'if you would like parallelization. Resetting '

--- a/pyls/compute.py
+++ b/pyls/compute.py
@@ -260,16 +260,13 @@ def procrustes(original, permuted, singular):
     -------
     resamp : `numpy.ndarray`
         Singular values of rotated `permuted` matrix
-    rotate : `numpy.ndarray`
-        Matrix for rotating `permuted` to `original`
     """
 
     temp = original.T @ permuted
     N, _, P = randomized_svd(temp, n_components=min(temp.shape))
-    rotate = P.T @ N.T
-    resamp = permuted @ singular @ rotate
+    resamp = permuted @ singular @ (P.T @ N.T)
 
-    return resamp, rotate
+    return resamp
 
 
 def get_group_mean(X, Y, n_cond=1, mean_centering=0):

--- a/pyls/compute.py
+++ b/pyls/compute.py
@@ -214,7 +214,7 @@ def boot_ci(boot, ci=95):
     return lower, upper
 
 
-def boot_rel(orig, boot):
+def boot_rel(orig, u_sum, u_square, n_boot):
     """
     Determines bootstrap ratios (BSR) of saliences from bootstrap distributions
 
@@ -222,8 +222,12 @@ def boot_rel(orig, boot):
     ----------
     orig : (G, L) array_like
         Original singular vectors
-    boot : (G, L, B) array_like
-        Bootstrapped singular vectors, where `B` is bootstraps
+    u_sum : (G, L) array_like
+        Sum of bootstrapped singular vectors
+    u_square : (G, L) array_like
+        Sum of squared bootstraped singular vectors
+    n_boot : int
+        Number of bootstraps used in generating `u_sum` and `u_square`
 
     Returns
     -------
@@ -231,7 +235,8 @@ def boot_rel(orig, boot):
         Bootstrap ratios for provided singular vectors
     """
 
-    u_se = boot.std(axis=-1, ddof=1)  # matlab PLS doesn't use stderr
+    u_sum2 = (u_sum ** 2) / n_boot
+    u_se = np.sqrt(np.abs(u_square - u_sum2) / (n_boot - 1))
     bsr = orig / u_se
 
     return bsr, u_se

--- a/pyls/io.py
+++ b/pyls/io.py
@@ -98,7 +98,7 @@ def load_results(fname):
         results = dict()
         for key, item in h5file[group].items():
             if isinstance(item, h5py.Dataset):
-                results[key] = item.value
+                results[key] = item[()]
             elif isinstance(item, h5py.Group):
                 results[key] = _recursive_load(h5file, group=group + '/' + key)
         for key, value in h5file[group].attrs.items():

--- a/pyls/structures.py
+++ b/pyls/structures.py
@@ -144,7 +144,7 @@ class PLSInputs(ResDict):
             if n_proc == 'max' or n_proc == -1:
                 self['n_proc'] = cpu_count()
             elif n_proc < 0:
-                self['n_proc'] = cpu_count() + n_proc
+                self['n_proc'] = cpu_count() + 1 + n_proc
 
         ts = self.get('test_size')
         if ts is not None and (ts < 0 or ts >= 1):

--- a/pyls/structures.py
+++ b/pyls/structures.py
@@ -139,8 +139,12 @@ class PLSInputs(ResDict):
         if self.get('test_split') == 0:
             self['test_split'] = None
 
-        if self.get('n_proc') == 'max':
-            self['n_proc'] = cpu_count()
+        if self.get('n_proc') is not None:
+            n_proc = self.get('n_proc')
+            if n_proc == 'max' or n_proc == -1:
+                self['n_proc'] = cpu_count()
+            elif n_proc < 0:
+                self['n_proc'] = cpu_count() + n_proc
 
         ts = self.get('test_size')
         if ts is not None and (ts < 0 or ts >= 1):

--- a/pyls/tests/conftest.py
+++ b/pyls/tests/conftest.py
@@ -28,3 +28,13 @@ def bpls_results():
     rs = np.random.RandomState(1234)
     return pyls.behavioral_pls(rs.rand(subj, Xf), rs.rand(subj, Yf),
                                n_perm=10, n_boot=10, n_split=10)
+
+
+@pytest.fixture(scope='session')
+def pls_inputs():
+    return dict(X=np.random.rand(100, 1000), Y=np.random.rand(100, 100),
+                groups=[50, 50], n_cond=1, mean_centering=0,
+                n_perm=10, n_boot=10, n_split=5,
+                test_size=0.25, test_split=100, n_proc=2,
+                rotate=True, ci=95, seed=1234, verbose=True,
+                permsamples=10, bootsamples=10)

--- a/pyls/tests/conftest.py
+++ b/pyls/tests/conftest.py
@@ -35,6 +35,6 @@ def pls_inputs():
     return dict(X=np.random.rand(100, 1000), Y=np.random.rand(100, 100),
                 groups=[50, 50], n_cond=1, mean_centering=0,
                 n_perm=10, n_boot=10, n_split=5,
-                test_size=0.25, test_split=100, n_proc=2,
+                test_size=0.25, test_split=100,
                 rotate=True, ci=95, seed=1234, verbose=True,
                 permsamples=10, bootsamples=10)

--- a/pyls/tests/matlab.py
+++ b/pyls/tests/matlab.py
@@ -245,6 +245,10 @@ def assert_matlab_equivalence(fname, method=None, corr=0.975, alpha=0.05,
     # use seed for reproducibility of re-analysis
     matlab.inputs.seed = 1234
     matlab.inputs.verbose = False
+    # don't update n_split if it was previously set to None
+    if matlab.inputs.n_split is None:
+        if 'n_split' in kwargs:
+            kwargs.pop('n_split')
     matlab.inputs.update(kwargs)
 
     # run PLS

--- a/pyls/tests/matlab.py
+++ b/pyls/tests/matlab.py
@@ -33,7 +33,7 @@ def assert_num_equiv(a, b, atol=1e-4):
     assert np.allclose(diff, 0, atol=atol)
 
 
-def assert_func_equiv(a, b, corr=0.975):
+def assert_func_equiv(a, b, corr=0.975, ftol=0.01):
     """
     Asserts "functional" equivalence of `a` and `b`
 
@@ -53,6 +53,10 @@ def assert_func_equiv(a, b, corr=0.975):
     corr : [0, 1] float, optional
         Correlation that must be surpassed in order to achieve functional
         equivalence between `a` and `b`. Default: 0.99
+    ftol : float, optional
+        If len(a) and len(b) <= 2, the correlation cannot be used to assess
+        functional equivalence. Instead, this specifies the numerical tolerance
+        permitted between corresponding values in the two vectors.
 
     Raises
     ------
@@ -63,9 +67,9 @@ def assert_func_equiv(a, b, corr=0.975):
     if len(a) == 1 and len(b) == 1:  # can't do anything here, really...
         return
     elif len(a) <= 2 and len(b) <= 2:  # can't correlate length 2 array...
-        # ensure that the sign change is consistent between arrays
-        diff = a - b
-        assert np.all(np.sign(diff) == 1) or np.all(np.sign(diff) == -1)
+        assert np.allclose(np.sign(a), np.sign(b))
+        if ftol is not None:
+            assert np.all(np.abs(a - b) < ftol)
         return
 
     if a.ndim > 1:
@@ -101,7 +105,8 @@ def assert_pvals_equiv(a, b, alpha=0.05):
     assert np.all((a < alpha) == (b < alpha))
 
 
-def compare_python_matlab(python, matlab, corr=0.975, alpha=0.05):
+def compare_python_matlab(python, matlab, *, atol=1e-4, corr=0.975, alpha=0.05,
+                          ftol=0.01):
     """
     Compares PLS results generated from `python` and `matlab`
 
@@ -109,7 +114,7 @@ def compare_python_matlab(python, matlab, corr=0.975, alpha=0.05):
     propagate through permutation testing and bootstrap resampling, we cannot
     expected that PLS results from Python and Matlab will generate _exactly_
     the same results. This function compares the numerical eqivalence of
-    results we do expect to be exactly, and assess the functional equivalence
+    results we do expect to be exact, and assesses the functional equivalence
     of the remaining results using correlations and alpha testing, as
     appropriate.
 
@@ -119,13 +124,21 @@ def compare_python_matlab(python, matlab, corr=0.975, alpha=0.05):
         PLSResults object generated from Python
     matlab : :obj:`pyls.PLSResults`
         PLSResults object generated from Matlab
+    atol : float, optional
+        Absolute tolerance permitted between `python` and `matlab` results
+        that should have numerical equivalency. Default: 1e-4
     corr : [0, 1] float, optional
         Minimum correlation expected between `python` and `matlab` results
-        that can't be expected to retain numerical equivalency
+        that can't be expected to retain numerical equivalency. Default: 0.975
     alpha : [0, 1] float, optional
         Alpha level for assessing significance of latent variables, used to
         compare whether `python` and `matlab` results retain same functional
-        significance
+        significance. Default: 0.05
+    ftol : float, optional
+        If len(a) and len(b) <= 2, the correlation ( `corr`) cannot be used to
+        assess functional equivalence. Instead, this value specifies the
+        numerical tolerance allowed between corresponding values in the two
+        vectors. Default: 0.01
 
     Returns
     -------
@@ -136,53 +149,57 @@ def compare_python_matlab(python, matlab, corr=0.975, alpha=0.05):
         If `equivalent=False`, reason for failure; otherwise, empty string
     """
 
+    if not isinstance(python, pyls.PLSResults):
+        raise ValueError('Provided `python` object must be a pyls.PLSResults '
+                         'instance, not {}.'.format(type(python)))
+    if not isinstance(matlab, pyls.PLSResults):
+        raise ValueError('Provided `matlab` object must be a pyls.PLSResults '
+                         'instance, not {}.'.format(type(matlab)))
+
     # singular values close to 0 cannot be considered because they're random
     keep = ~np.isclose(python.s, 0)
 
     # check top-level results
     for k in python.keys():
         if isinstance(python[k], np.ndarray):
+            a, b = python[k][..., keep], matlab[k][..., keep]
             try:
-                assert_num_equiv(python[k][..., keep], matlab[k][..., keep])
+                assert_num_equiv(a, b, atol=atol)
             except AssertionError:
                 return False, k
 
     # check pvals for functional equivalence
     if matlab.get('permres', {}).get('pvals') is not None:
+        a, b = python.permres.pvals[keep], matlab.permres.pvals[keep]
         try:
-            assert_func_equiv(python.permres.pvals[keep],
-                              matlab.permres.pvals[keep],
-                              corr)
-            assert_pvals_equiv(python.permres.pvals[keep],
-                               matlab.permres.pvals[keep],
-                               alpha)
+            assert_func_equiv(a, b, corr, ftol=ftol)
+            assert_pvals_equiv(a, b, alpha)
         except AssertionError:
             return False, 'permres.pvals'
 
     # check bootstraps for functional equivalence
     if matlab.get('bootres', {}).get('bootstrapratios') is not None:
+        a = python.bootres.bootstrapratios[..., keep]
+        b = matlab.bootres.bootstrapratios[..., keep]
         try:
-            assert_func_equiv(python.bootres.bootstrapratios[..., keep],
-                              matlab.bootres.bootstrapratios[..., keep],
-                              corr)
+            assert_func_equiv(a, b, corr, ftol=ftol)
         except AssertionError:
             return False, 'bootres.bootstrapratios'
 
     # check splitcorr for functional equivalence
     if matlab.get('splitres', {}).get('ucorr') is not None:
-        # lenient functional equivalence
+        a, b = python.splitres, matlab.splitres
         try:
             for k in ['ucorr', 'vcorr']:
-                assert_func_equiv(python.splitres[k][keep],
-                                  matlab.splitres[k][keep], corr)
+                assert_func_equiv(a[k][keep], b[k][keep], corr, ftol=ftol)
         except AssertionError:
             return False, 'splitres.{}'.format(k)
 
     return True, ''
 
 
-def assert_matlab_equivalence(fname, method=None, corr=0.975, alpha=0.05,
-                              **kwargs):
+def assert_matlab_equivalence(fname, method=None, *, atol=1e-4, corr=0.975,
+                              alpha=0.05, ftol=0.01, **kwargs):
     """
     Compares Matlab PLS results stored in `fname` with Python-generated results
 
@@ -196,14 +213,21 @@ def assert_matlab_equivalence(fname, method=None, corr=0.975, alpha=0.05,
     method : function, optional
         PLS function to use to re-run analysis from `fname`. If not specified
         will try and determine method from `fname`. Default: None
+    atol : float, optional
+        Absolute tolerance permitted between `python` and `matlab` results
+        that should have numerical equivalency. Default: 1e-4
     corr : [0, 1] float, optional
-        Minimum correlation expected between Matlab and Python PLS results that
-        can't be expected to retain numerical equivalency (i.e., permutation
-        results, bootstrapping results)
+        Minimum correlation expected between `python` and `matlab` results
+        that can't be expected to retain numerical equivalency. Default: 0.975
     alpha : [0, 1] float, optional
         Alpha level for assessing significance of latent variables, used to
-        compare whether Matlab and Python PLS results retain same functional
-        significance
+        compare whether `python` and `matlab` results retain same functional
+        significance. Default: 0.05
+    ftol : float, optional
+        If len(a) and len(b) <= 2, the correlation ( `corr`) cannot be used to
+        assess functional equivalence. Instead, this value specifies the
+        numerical tolerance allowed between corresponding values in the two
+        vectors. Default: 0.01
     kwargs : optional
         Key-value arguments to provide to PLS analysis. May override arguments
         specified in `fname`
@@ -253,7 +277,8 @@ def assert_matlab_equivalence(fname, method=None, corr=0.975, alpha=0.05,
 
     # run PLS
     python = fcn(**matlab.inputs)
-    equiv, reason = compare_python_matlab(python, matlab, corr, alpha)
+    equiv, reason = compare_python_matlab(python, matlab, atol=atol, corr=corr,
+                                          alpha=alpha, ftol=ftol)
 
     if not equiv:
         raise AssertionError('compare_matlab_result failed: {}'.format(reason))

--- a/pyls/tests/test_base.py
+++ b/pyls/tests/test_base.py
@@ -5,16 +5,176 @@ import pytest
 import pyls
 
 
+# tests for gen_permsamp(), gen_bootsamp(), and gen_splitsamp() are all very
+# similar because the code behind them is, in many senses, redundant.
+# that being said, the differences between the functions are intricate enough
+# that extracting the shared functionality would be more difficult than anyone
+# has time for right now.
+# thus, we get repetitive tests to make sure that nothing is screwed up!
+def test_gen_permsamp():
+    # test to make sure that there are no duplicates generated given a
+    # sufficiently large number of samples / conditions to work with
+    unique_perms = pyls.base.gen_permsamp([10, 10], 2, seed=1234, n_perm=10)
+    assert unique_perms.shape == (40, 10)
+    for n, perm in enumerate(unique_perms.T[::-1], 1):
+        assert not (perm[:, None] == unique_perms[:, :-n]).all(axis=0).any()
+
+    # test that random state works and gives equivalent permutations when
+    # the same number of groups / conditions / permutations are provided
+    same_perms = pyls.base.gen_permsamp([10, 10], 2, seed=1234, n_perm=10)
+    assert same_perms.shape == (40, 10)
+    assert np.all(unique_perms == same_perms)
+
+    # test that, given a small number of samples and requesting a large number
+    # of permutations, duplicate samples are given (and a warning is raised!)
+    with pytest.warns(UserWarning):
+        dupe_perms = pyls.base.gen_permsamp([2, 2], 1, n_perm=25)
+    assert dupe_perms.shape == (4, 25)
+    dupe = False
+    for n, perm in enumerate(dupe_perms.T[::-1], 1):
+        dupe = dupe or (perm[:, None] == dupe_perms[:, :-n]).all(axis=0).any()
+    assert dupe
+
+    # test that subject conditions are kept together during permutations
+    # that is, each subject has two conditions so we want to make sure that
+    # when we permute subject order both conditions for a given subject are
+    # moved together
+    cond_perms = pyls.base.gen_permsamp([10], 2, n_perm=10)
+    assert cond_perms.shape == (20, 10)
+    for n in range(10):
+        comp = np.array([f + 10 if f < 10 else f - 10 for f in cond_perms[n]])
+        assert np.all(comp == cond_perms[n + 10])
+
+    # test that subjects are permuted between groups
+    # that is, no permutation should result in a group having the same subjects
+    group_perms = pyls.base.gen_permsamp([10, 10], 1, n_perm=10)
+    g1, g2 = np.sort(group_perms[:10], 0), np.sort(group_perms[10:], 0)
+    comp = np.arange(0, 10)[:, None]
+    assert not np.any(np.all(comp == g1, axis=0))
+    assert not np.any(np.all((comp + 10) == g2, axis=0))
+
+    # test that permutations with groups and conditions are appropriate
+    # we'll use unique_perms since that has 2 groups and 2 conditions already
+    # we want to confirm that (1) subject conditions are permuted together, and
+    # (2) subjects are permuted between groups
+    g1, g2 = unique_perms[:20], unique_perms[20:]
+    # confirm subject conditions are permuted together
+    for g in [g1, g2]:
+        for n in range(10):
+            comp = [f + 10 if f < 10 or (f >= 20 and f < 30) else f - 10
+                    for f in g[n]]
+            assert np.all(comp == g[n + 10])
+    # confirm subjects perare muted between groups
+    comp = np.arange(0, 20)[:, None]
+    assert not np.any(np.all(comp == np.sort(g1, axis=0), axis=0))
+    assert not np.any(np.all((comp + 20) == np.sort(g2, axis=0), axis=0))
+
+
+def test_gen_bootsamp():
+    # test to make sure that there are no duplicates generated given a
+    # sufficiently large number of samples / conditions to work with
+    unique_boots = pyls.base.gen_bootsamp([10, 10], 2, seed=1234, n_boot=10)
+    assert unique_boots.shape == (40, 10)
+    for n, perm in enumerate(unique_boots.T[::-1], 1):
+        assert not (perm[:, None] == unique_boots[:, :-n]).all(axis=0).any()
+
+    # test that random state works and gives equivalent bootstraps when
+    # the same number of groups / conditions / bootstraps are provided
+    same_boots = pyls.base.gen_bootsamp([10, 10], 2, seed=1234, n_boot=10)
+    assert same_boots.shape == (40, 10)
+    assert np.all(unique_boots == same_boots)
+
+    # test that, given a small number of samples and requesting a large number
+    # of bootstraps, duplicate samples are given (and a warning is raised!)
+    with pytest.warns(UserWarning):
+        dupe_boots = pyls.base.gen_bootsamp([5], 1, n_boot=125)
+    assert dupe_boots.shape == (5, 125)
+    dupe = False
+    for n, perm in enumerate(dupe_boots.T[::-1], 1):
+        dupe = dupe or (perm[:, None] == dupe_boots[:, :-n]).all(axis=0).any()
+    assert dupe
+
+    # test that bootstraps all have the minimum number of unique subjects
+    # that is, since we are always bootstrapping within groups/conditions, we
+    # want to ensure that there is never a case where e.g., an entire group is
+    # replaced with ONE subject (unless there are only two subjects, but then
+    # what are you really doing?)
+    # we set a minumum subject threshold equal to 1/2 the number of samples in
+    # the smallest group; thus, with e.g., groups of [10, 20, 30], the minimum
+    # number of unique subjects in any given group for any given bootstrap
+    # should be 5 (=10/2)
+    for grp in np.split(unique_boots, 4, axis=0):
+        for boot in grp.T:
+            assert np.unique(boot).size >= 5
+
+    # make sure that when we're resampling subjects we're doing it for all
+    # conditions; this is a much easier check than for permutations!
+    for n in range(10):
+        assert np.all(unique_boots[n] + 10 == unique_boots[n + 10])
+    for n in range(20, 30):
+        assert np.all(unique_boots[n] + 10 == unique_boots[n + 10])
+
+
+def test_gen_splitsamp():
+    # test to make sure that there are no duplicates generated given a
+    # sufficiently large number of samples / conditions to work with
+    unique_splits = pyls.base.gen_splits([10, 10], 2, seed=1234, n_split=10)
+    assert unique_splits.shape == (40, 10)
+    for n, perm in enumerate(unique_splits.T[::-1], 1):
+        assert not (perm[:, None] == unique_splits[:, :-n]).all(axis=0).any()
+
+    # test that random state works and gives equivalent splits when
+    # the same number of groups / conditions / splits are provided
+    same_splits = pyls.base.gen_splits([10, 10], 2, seed=1234, n_split=10)
+    assert same_splits.shape == (40, 10)
+    assert np.all(unique_splits == same_splits)
+
+    # test that, given a small number of samples and requesting a large number
+    # of splits, duplicate samples are given (and a warning is raised!)
+    with pytest.warns(UserWarning):
+        dupe_splits = pyls.base.gen_splits([5], 1, n_split=125)
+    assert dupe_splits.shape == (5, 125)
+    dupe = False
+    for n, perm in enumerate(dupe_splits.T[::-1], 1):
+        dupe = dupe or (perm[:, None] == dupe_splits[:, :-n]).all(axis=0).any()
+    assert dupe
+
+    # make sure that each group is split independently!
+    for grp in np.split(unique_splits, 4, axis=0):
+        assert np.all(np.sum(grp, axis=0) == 5)
+
+    # make sure that `test_size` works as expected, too
+    # `test_size` should determine the proportion of values set to False in
+    # each group x condition
+    # by default, `test_size` is 0.5, so the split is half-and-half, but if we
+    # change it to e.g., 0.2, then there should be `0.2 * n_samples` False
+    # values in each group x condition
+    test_splits = pyls.base.gen_splits([10, 10], 2, n_split=10, test_size=0.2)
+    for grp in np.split(test_splits, 4, axis=0):
+        assert np.all(np.sum(grp, axis=0) == 8)
+
+
 def test_BasePLS(pls_inputs):
+    # test that BasePLS accepts all inputs and stores them correctly
     basepls = pyls.base.BasePLS(**pls_inputs)
     for key in pls_inputs.keys():
         assert hasattr(basepls.inputs, key)
-        assert np.all(getattr(basepls.inputs, key) == pls_inputs[key])
+        assert np.all(basepls.inputs[key] == pls_inputs[key])
 
+    # test that groups are handled correctly
+    X, n_samples = pls_inputs['X'], len(pls_inputs['X'])
+    # when not provided, should be calculated
+    basepls = pyls.base.BasePLS(X, n_cond=2)
+    assert basepls.inputs.groups == [n_samples // 2]
+    # when provided as an int, should be coerced into a list
+    basepls = pyls.base.BasePLS(X, groups=n_samples // 2, n_cond=2)
+    assert basepls.inputs.groups == [n_samples // 2]
+    # when they don't match the number of samples in the input data, error
+    with pytest.raises(ValueError):
+        basepls = pyls.base.BasePLS(X, groups=[100, 100])
+
+    # ensure errors are raised for not implemented
     with pytest.raises(NotImplementedError):
         basepls.gen_covcorr(pls_inputs['X'], pls_inputs['Y'])
     with pytest.raises(NotImplementedError):
         basepls.gen_distrib(pls_inputs['X'], pls_inputs['Y'])
-    with pytest.raises(ValueError):
-        pls_inputs['groups'] = [100, 100]
-        basepls = pyls.base.BasePLS(**pls_inputs)

--- a/pyls/tests/test_base.py
+++ b/pyls/tests/test_base.py
@@ -48,6 +48,8 @@ def test_BasePLS():
 
     with pytest.raises(NotImplementedError):
         basepls.gen_covcorr(X, Y, groups)
+    with pytest.raises(NotImplementedError):
+        basepls.gen_distrib(X, Y, groups)
     with pytest.raises(ValueError):
         opts['groups'] = [100, 100]
         basepls = pyls.base.BasePLS(**opts)

--- a/pyls/tests/test_base.py
+++ b/pyls/tests/test_base.py
@@ -5,51 +5,16 @@ import pytest
 import pyls
 
 
-n_cond = 1
-n_perm = 50
-n_boot = 10
-n_split = 5
-seed = 1234
-groups = [50, 50]
-test_size = 0.25
-mean_centering = 0
-rotate = True
-
-np.random.rand(seed)
-X = np.random.rand(100, 1000)
-Y = np.random.rand(100, 100)
-
-opts = dict(X=X, Y=Y,
-            groups=groups, n_cond=n_cond, mean_centering=mean_centering,
-            n_perm=n_perm, n_boot=n_boot, n_split=n_split, test_size=test_size,
-            rotate=rotate, ci=95, seed=seed, verbose=True)
-
-attrs = ['X', 'Y', 'groups', 'n_cond', 'n_perm', 'n_boot', 'n_split',
-         'test_size', 'mean_centering', 'rotate', 'ci', 'seed']
-
-
-def test_PLSInputs():
-    pls_inputs = pyls.structures.PLSInputs(**opts)
-    for key in attrs:
-        assert hasattr(pls_inputs, key)
-        assert np.all(getattr(pls_inputs, key) == opts[key])
-
-    assert pyls.structures.PLSInputs(n_split=0).n_split is None
-
-    with pytest.raises(ValueError):
-        pyls.structures.PLSInputs(test_size=1)
-
-
-def test_BasePLS():
-    basepls = pyls.base.BasePLS(**opts)
-    for key in attrs:
+def test_BasePLS(pls_inputs):
+    basepls = pyls.base.BasePLS(**pls_inputs)
+    for key in pls_inputs.keys():
         assert hasattr(basepls.inputs, key)
-        assert np.all(getattr(basepls.inputs, key) == opts[key])
+        assert np.all(getattr(basepls.inputs, key) == pls_inputs[key])
 
     with pytest.raises(NotImplementedError):
-        basepls.gen_covcorr(X, Y, groups)
+        basepls.gen_covcorr(pls_inputs['X'], pls_inputs['Y'])
     with pytest.raises(NotImplementedError):
-        basepls.gen_distrib(X, Y, groups)
+        basepls.gen_distrib(pls_inputs['X'], pls_inputs['Y'])
     with pytest.raises(ValueError):
-        opts['groups'] = [100, 100]
-        basepls = pyls.base.BasePLS(**opts)
+        pls_inputs['groups'] = [100, 100]
+        basepls = pyls.base.BasePLS(**pls_inputs)

--- a/pyls/tests/test_structures.py
+++ b/pyls/tests/test_structures.py
@@ -1,0 +1,57 @@
+# -*- coding: utf-8 -*-
+
+import multiprocessing as mp
+import numpy as np
+import pytest
+from pyls import structures
+
+
+def test_PLSInputs(pls_inputs):
+    # check correct handling of all available PLSInputs keys
+    pls_inputs = structures.PLSInputs(**pls_inputs)
+    for key in pls_inputs.keys():
+        assert hasattr(pls_inputs, key)
+        assert np.all(getattr(pls_inputs, key) == pls_inputs[key])
+
+    # test_split and n_split should be None when set to 0
+    assert structures.PLSInputs(n_split=0).n_split is None
+    assert structures.PLSInputs(test_split=0).test_split is None
+
+    # confirm n_proc inputs are handled appropriately
+    for n_proc in ['max', -1]:
+        assert structures.PLSInputs(n_proc=n_proc).n_proc == mp.cpu_count()
+    assert structures.PLSInputs(n_proc=-2).n_proc == mp.cpu_count() - 1
+
+    # check input checking for test_size
+    with pytest.raises(ValueError):
+        structures.PLSInputs(test_size=1)
+    with pytest.raises(ValueError):
+        structures.PLSInputs(test_size=-0.5)
+
+    # check that PLSInputs rejects disallowed keys
+    assert structures.PLSInputs(notakey=10).get('notakey') is None
+
+
+@pytest.mark.xfail
+def test_PLSResults():
+    pass
+
+
+@pytest.mark.xfail
+def test_PLSBootResults():
+    pass
+
+
+@pytest.mark.xfail
+def test_PLSPermResults():
+    pass
+
+
+@pytest.mark.xfail
+def test_PLSSplitHalfResults():
+    pass
+
+
+@pytest.mark.xfail
+def test_PLSCrossValidationResults():
+    pass

--- a/pyls/tests/test_structures.py
+++ b/pyls/tests/test_structures.py
@@ -18,6 +18,7 @@ def test_PLSInputs(pls_inputs):
     assert structures.PLSInputs(test_split=0).test_split is None
 
     # confirm n_proc inputs are handled appropriately
+    assert structures.PLSInputs(n_proc=1).n_proc == 1
     for n_proc in ['max', -1]:
         assert structures.PLSInputs(n_proc=n_proc).n_proc == mp.cpu_count()
     assert structures.PLSInputs(n_proc=-2).n_proc == mp.cpu_count() - 1

--- a/pyls/tests/test_utils.py
+++ b/pyls/tests/test_utils.py
@@ -145,7 +145,7 @@ def test_get_par_func():
 
     if not utils.joblib_avail:
         par, func = utils.get_par_func(1000, fcn)
-        assert par == utils._unravel
+        assert isinstance(par, utils._unravel)
         assert fcn == func
     else:
         import joblib

--- a/pyls/tests/test_utils.py
+++ b/pyls/tests/test_utils.py
@@ -143,13 +143,14 @@ def test_get_par_func():
     assert fcn(10) == 10
     assert fcn([10, 10]) == [10, 10]
 
-    if not utils.joblib_avail:
-        par, func = utils.get_par_func(1000, fcn)
-        assert isinstance(par, utils._unravel)
-        assert fcn == func
-    else:
+    if utils.joblib_avail:
         import joblib
         par, func = utils.get_par_func(1000, fcn)
         assert isinstance(par, joblib.Parallel)
         assert par.n_jobs == 1000
         assert not fcn == func
+
+        utils.joblib_avail = False
+        par, func = utils.get_par_func(1000, fcn)
+        assert isinstance(par, utils._unravel)
+        assert fcn == func

--- a/pyls/tests/test_utils.py
+++ b/pyls/tests/test_utils.py
@@ -86,7 +86,7 @@ def test_ResDict():
 def test_trange():
     # test that verbose=False generates a range object
     out = utils.trange(1000, verbose=False, desc='Test tqdm')
-    assert out == range(1000)
+    assert [f for f in out] == list(range(1000))
     # test that function will accept arbitrary kwargs and overwrite defaults
     out = utils.trange(1000, desc='Test tqdm', mininterval=0.5, ascii=False)
     assert isinstance(out, tqdm.tqdm)
@@ -128,14 +128,20 @@ def test_permute_cols():
 
 def test_unravel():
     expected = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
-    assert utils._unravel(range(10)) == expected
+    assert utils._unravel()(range(10)) == expected
     expected = [0, 1, 4, 9, 16, 25, 36, 49, 64, 81]
-    assert utils._unravel(x ** 2 for x in range(10)) == expected
+    assert utils._unravel()(x ** 2 for x in range(10)) == expected
+
+    # test context manager status and arbitrary argument acceptance
+    with utils._unravel(10, test=20) as cm:
+        assert cm(x**2 for x in range(10)) == expected
 
 
 def test_get_par_func():
     def fcn(x):
         return x
+    assert fcn(10) == 10
+    assert fcn([10, 10]) == [10, 10]
 
     if not utils.joblib_avail:
         par, func = utils.get_par_func(1000, fcn)

--- a/pyls/types/behavioral.py
+++ b/pyls/types/behavioral.py
@@ -109,7 +109,7 @@ class BehavioralPLS(BasePLS):
 
         return self.gen_covcorr(tusc, Y, groups=groups)
 
-    def crossval(self, X, Y, seed=None, verbose=True):
+    def crossval(self, X, Y, seed=None):
         """
         Performs cross-validation of SVD of `X` and `Y`
 
@@ -121,8 +121,6 @@ class BehavioralPLS(BasePLS):
             Input data matrix, where `S` is observations and `T` is features
         seed : {int, :obj:`numpy.random.RandomState`, None}, optional
             Seed for random number generation. Default: None
-        verbose : bool, optional
-            Whether to print status updates as CV is calculated. Default: True
 
         Returns
         -------
@@ -138,19 +136,19 @@ class BehavioralPLS(BasePLS):
                             self.inputs.test_split,
                             seed=seed,
                             test_size=self.inputs.test_size)
-        dummy = utils.dummy_code(self.inputs.groups, self.inputs.n_cond)
+        groups = utils.dummy_code(self.inputs.groups, self.inputs.n_cond)
 
         parallel, func = utils.get_par_func(self.inputs.n_proc,
                                             self.__class__._single_crossval)
-        generator = utils.trange(self.inputs.test_split, verbose=verbose,
-                                 desc='Running cross-validation')
-        out = parallel(func(self, X=X, Y=Y, dummy=dummy,
-                            inds=splits[:, i], seed=i) for i in generator)
+        gen = utils.trange(self.inputs.test_split, verbose=self.inputs.verbose,
+                           desc='Running cross-validation')
+        out = parallel(func(self, X=X, Y=Y, inds=splits[:, i],
+                            groups=groups, seed=i) for i in gen)
         r_scores, r2_scores = [np.stack(o, axis=-1) for o in zip(*out)]
 
         return r_scores, r2_scores
 
-    def _single_crossval(self, X, Y, dummy, inds, seed=None):
+    def _single_crossval(self, X, Y, inds, groups=None, seed=None):
         """
         Generates single cross-validated r and r^2 score
 
@@ -164,14 +162,17 @@ class BehavioralPLS(BasePLS):
             Seed for random number generation. Default: None
         """
 
-        X_train, Y_train, dummy_train = X[inds], Y[inds], dummy[inds]
-        X_test, Y_test, dummy_test = X[~inds], Y[~inds], dummy[~inds]
+        if groups is None:
+            groups = utils.dummy_code(self.inputs.groups, self.inputs.n_cond)
+
+        X_train, Y_train, dummy_train = X[inds], Y[inds], groups[inds]
+        X_test, Y_test, dummy_test = X[~inds], Y[~inds], groups[~inds]
         # perform initial decomposition on train set
-        U, d, V = self.svd(X_train, Y_train, dummy=dummy_train, seed=seed)
+        U, d, V = self.svd(X_train, Y_train, groups=dummy_train, seed=seed)
 
         # rescale the test set based on the training set
         Y_pred = []
-        for n, V_spl in enumerate(np.split(V, dummy.shape[-1])):
+        for n, V_spl in enumerate(np.split(V, groups.shape[-1])):
             tr_grp = dummy_train[:, n].astype(bool)
             te_grp = dummy_test[:, n].astype(bool)
             rescaled = compute.rescale_test(X_train[tr_grp], X_test[te_grp],
@@ -209,13 +210,15 @@ class BehavioralPLS(BasePLS):
         groups = utils.dummy_code(self.inputs.groups, self.inputs.n_cond)
         res.behavcorr = self.gen_covcorr(res.brainscores, Y, groups)
 
-        # compute bootstraps and BSRs
         if self.inputs.n_boot > 0:
+            # compute bootstraps
             distrib, u_sum, u_square = self.bootstrap(X, Y, self.rs)
 
             # add original scaled singular vectors back in
             bs = res.u @ res.s
             u_sum, u_square = u_sum + bs, u_square + (bs ** 2)
+
+            # calculate bootstrap ratios and confidence intervals
             bsrs, uboot_se = compute.boot_rel(bs, u_sum, u_square,
                                               self.inputs.n_boot + 1)
             llcorr, ulcorr = compute.boot_ci(distrib, ci=self.inputs.ci)
@@ -231,8 +234,7 @@ class BehavioralPLS(BasePLS):
 
         # compute cross-validated prediction-based metrics
         if self.inputs.test_split is not None and self.inputs.test_size > 0:
-            r, r2 = self.crossval(X, Y, seed=self.rs,
-                                  verbose=self.inputs.verbose)
+            r, r2 = self.crossval(X, Y, seed=self.rs)
             res.cvres.update(dict(pearson_r=r, r_squared=r2))
 
         # get rid of the stupid diagonal matrix
@@ -254,7 +256,7 @@ def behavioral_pls(X, Y, *, groups=None, n_cond=1, n_perm=5000, n_boot=5000,
     return pls.results
 
 
-behavioral_pls.__doc__ = r"""\
+behavioral_pls.__doc__ = r"""
 Performs behavioral PLS on `X` and `Y`.
 
 Behavioral PLS is a multivariate statistical approach that relates two sets

--- a/pyls/types/meancentered.py
+++ b/pyls/types/meancentered.py
@@ -130,7 +130,10 @@ class MeanCenteredPLS(BasePLS):
         res.brainscores_dm = brainscores_dm
 
         if self.inputs.n_boot > 0:
+            # compute bootstraps
             distrib, u_sum, u_square = self.bootstrap(X, Y, self.rs)
+
+            # calculate bootstrap ratios and confidence intervals
             bsrs, uboot_se = compute.boot_rel(res.u @ res.s, u_sum, u_square,
                                               self.inputs.n_boot)
             llcorr, ulcorr = compute.boot_ci(distrib, ci=self.inputs.ci)
@@ -161,7 +164,7 @@ def meancentered_pls(X, *, groups=None, n_cond=1, mean_centering=0,
     return pls.results
 
 
-meancentered_pls.__doc__ = r"""\
+meancentered_pls.__doc__ = r"""
 Performs mean-centered PLS on `X`, sorted into `groups` and `conditions`.
 
 Mean-centered PLS is a multivariate statistical approach that attempts to

--- a/pyls/utils.py
+++ b/pyls/utils.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+from contextlib import contextmanager
 import numpy as np
 import tqdm
 from sklearn.utils import Bunch
@@ -223,7 +224,7 @@ def permute_cols(x, seed=None):
     return x[ix_i, ix_j]
 
 
-def _unravel(x):
+class _unravel():
     """
     Small utility to unravel generator object into a list
 
@@ -235,8 +236,14 @@ def _unravel(x):
     -------
     y : list
     """
+    def __call__(self, x):
+        return [f for f in x]
 
-    return [f for f in x]
+    def __enter__(self, *args, **kwargs):
+        return self
+
+    def __exit__(self, *args, **kwargs):
+        pass
 
 
 def get_par_func(n_proc, func, **kwargs):
@@ -263,6 +270,6 @@ def get_par_func(n_proc, func, **kwargs):
                             **kwargs)
         func = delayed(func)
     else:
-        parallel = _unravel
+        parallel = _unravel()
 
     return parallel, func

--- a/pyls/utils.py
+++ b/pyls/utils.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from contextlib import contextmanager
 import numpy as np
 import tqdm
 from sklearn.utils import Bunch
@@ -141,8 +140,25 @@ def trange(n_iter, verbose=True, **kwargs):
     progbar : :obj:`tqdm.tqdm`
     """
 
+    class cmrange():
+        def __init__(self, n_iter):
+            self.n_iter = n_iter
+
+        def __enter__(self, *args, **kwargs):
+            return self
+
+        def __exit__(self, *args, **kwargs):
+            return
+
+        def __iter__(self):
+            for i in range(self.n_iter):
+                yield i
+
+        def update(self, *args, **kwargs):
+            return
+
     if not verbose:
-        return range(n_iter)
+        return cmrange(n_iter)
 
     form = ('{desc}: {percentage:3.0f}%|{bar}| {n_fmt}/{total_fmt}'
             ' | {elapsed}<{remaining}')
@@ -236,6 +252,9 @@ class _unravel():
     -------
     y : list
     """
+    def __init__(self, *args, **kwargs):
+        pass
+
     def __call__(self, x):
         return [f for f in x]
 

--- a/pyls/utils.py
+++ b/pyls/utils.py
@@ -266,7 +266,7 @@ def get_par_func(n_proc, func, **kwargs):
     """
 
     if joblib_avail:
-        parallel = Parallel(n_jobs=n_proc, max_nbytes=1e6, mmap_mode='r',
+        parallel = Parallel(n_jobs=n_proc, max_nbytes=1e6, mmap_mode='r+',
                             **kwargs)
         func = delayed(func)
     else:

--- a/pyls/utils.py
+++ b/pyls/utils.py
@@ -239,7 +239,7 @@ def _unravel(x):
     return [f for f in x]
 
 
-def get_par_func(n_proc, func):
+def get_par_func(n_proc, func, **kwargs):
     """
     Creates joblib-style parallelization function if joblib is available
 
@@ -259,7 +259,8 @@ def get_par_func(n_proc, func):
     """
 
     if joblib_avail:
-        parallel = Parallel(n_jobs=n_proc, max_nbytes=1e6, mmap_mode='r')
+        parallel = Parallel(n_jobs=n_proc, max_nbytes=1e6, mmap_mode='r',
+                            **kwargs)
         func = delayed(func)
     else:
         parallel = _unravel


### PR DESCRIPTION
We were previously saving the outputs of all the bootstrap resampling results; while this was fine for "small data," when neuroimaging data were used in conjunction with a high number of bootstraps this was HORRIBLY memory inefficient.

Addressing this when bootstraps are performed serially is fine; however, in order to maintain the ability to parallelize bootstraps we needed to change things up quite a bit. This PR attempts to addresses these issues while ensuring that parallel bootstrap computations, even with _giant_ data, don't fail miserably.