### PR TITLE
[ENH] Adds pls_regression() function

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -81,7 +81,7 @@ script:
       mkdir for_testing && cd for_testing;
       cp ../setup.cfg .;
       args="--cov-report term-missing --cov=pyls --doctest-modules --pyargs";
-      python -m pytest ${args} ${rootdir} pyls;
+      python -m pytest ${args} pyls;
     else
       false;
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -88,5 +88,5 @@ script:
 
 after_success:
   - if [ "${CHECK_TYPE}" == "test" ]; then
-      coveralls; codecov;
+      codecov;
     fi

--- a/docs/user_guide/results.rst
+++ b/docs/user_guide/results.rst
@@ -29,7 +29,7 @@ normally be displayed:
     >>> from pyls import behavioral_pls
     >>> results = behavioral_pls(**data, verbose=False)
     >>> results
-    PLSResults(u, s, v, brainscores, behavscores, behavcorr, permres, bootres, cvres, inputs)
+    PLSResults(x_weights, y_weights, x_scores, y_scores, y_loadings, singvals, varexp, permres, bootres, cvres, inputs)
 
 Printing the ``results`` object gives us a helpful view of some of the
 different outputs available to us. While we won't go into detail about all of

--- a/pyls/__init__.py
+++ b/pyls/__init__.py
@@ -2,8 +2,10 @@
 
 __all__ = [
     '__version__',
-    'behavioral_pls', 'meancentered_pls', 'import_matlab_result',
-    'examples', 'PLSInputs', 'PLSResults', 'save_results', 'load_results'
+    'behavioral_pls', 'meancentered_pls', 'pls_regression',
+    'import_matlab_result', 'save_results', 'load_results',
+    'examples', 'PLSInputs', 'PLSResults',
+
 ]
 
 from ._version import get_versions
@@ -14,4 +16,4 @@ from . import examples
 from .io import load_results, save_results
 from .matlab import import_matlab_result
 from .structures import PLSInputs, PLSResults
-from .types import (behavioral_pls, meancentered_pls)
+from .types import (behavioral_pls, meancentered_pls, pls_regression)

--- a/pyls/examples/datasets.json
+++ b/pyls/examples/datasets.json
@@ -51,6 +51,8 @@
         ],
         "X": "PLS_gene_predictor_vars.csv",
         "Y": "PLS_MRI_response_vars.csv",
-        "n_perm": 1000
+        "n_perm": 1000,
+        "n_boot": 1000,
+        "n_components": 2
     }
 }

--- a/pyls/io.py
+++ b/pyls/io.py
@@ -49,6 +49,8 @@ def save_results(fname, results):
             else:
                 if item is not None:
                     grp.attrs[key] = item
+                else:
+                    grp.attrs[key] = 'None'
 
     if not isinstance(fname, str):
         fname = str(fname)
@@ -100,6 +102,8 @@ def load_results(fname):
             elif isinstance(item, h5py.Group):
                 results[key] = _recursive_load(h5file, group=group + '/' + key)
         for key, value in h5file[group].attrs.items():
+            if isinstance(value, str) and value == 'None':
+                value = None
             results[key] = value
 
         return results

--- a/pyls/tests/test_examples.py
+++ b/pyls/tests/test_examples.py
@@ -40,7 +40,8 @@ def test_available_datasets():
         'description', 'reference', 'urls', 'X', 'n_perm', 'n_boot', 'groups'
     ]),
     ('whitaker_vertes_2016', [
-        'description', 'reference', 'urls', 'X', 'Y', 'n_perm'
+        'description', 'reference', 'urls', 'X', 'Y', 'n_perm', 'n_boot',
+        'n_components'
     ])
 ])
 def test_query_dataset(dataset, keys):
@@ -77,7 +78,7 @@ def test_get_data_dir(tmpdir):
     ('linnerud', ['X', 'Y', 'n_perm', 'n_boot']),
     ('mirchi_2018', ['X', 'Y', 'n_perm', 'n_boot', 'test_size', 'test_split']),
     ('wine', ['X', 'groups', 'n_perm', 'n_boot']),
-    ('whitaker_vertes_2016', ['X', 'Y', 'n_perm'])
+    ('whitaker_vertes_2016', ['X', 'Y', 'n_perm', 'n_boot', 'n_components'])
 ])
 def test_load_dataset(tmpdir, dataset, keys):
     ds = pyls.examples.load_dataset(dataset, str(tmpdir))

--- a/pyls/tests/test_matlab.py
+++ b/pyls/tests/test_matlab.py
@@ -12,7 +12,10 @@ EXAMPLES = ['mpls_multigroup_onecond_nosplit.mat',
             'bpls_onegroup_onecond_split.mat',
             'resultonly.mat']
 
-attrs = ['u', 's', 'v', 'brainscores', 'permres', 'bootres', 'inputs']
+attrs = [
+    'x_weights', 'singvals', 'y_weights', 'x_scores', 'permres', 'bootres',
+    'inputs'
+]
 
 
 @pytest.mark.parametrize('fname', EXAMPLES)

--- a/pyls/tests/test_types.py
+++ b/pyls/tests/test_types.py
@@ -13,10 +13,8 @@ rs = np.random.RandomState(1234)
 class PLSBaseTest():
     defaults = pyls.structures.PLSInputs(X=rs.rand(subj, Xf),
                                          Y=rs.rand(subj, Yf),
-                                         groups=None,
-                                         n_cond=1,
-                                         mean_centering=0,
-                                         rotate=True,
+                                         groups=None, n_cond=1,
+                                         mean_centering=0, rotate=True,
                                          n_perm=20, n_boot=10, n_split=None,
                                          ci=95, seed=rs, verbose=False)
     funcs = dict(meancentered=pyls.meancentered_pls,
@@ -49,12 +47,11 @@ class PLSBaseTest():
             behavior = num_lv = dummy
 
         attrs = [
-            ('u', (Xf, num_lv)),
-            ('s', (num_lv,)),
-            ('v', (behavior, num_lv)),
-            ('brainscores', (subj, num_lv)),
-            ('behavscores' if self.type == 'behavioral' else 'designscores',
-             (subj, num_lv))
+            ('x_weights', (Xf, num_lv)),
+            ('singvals', (num_lv,)),
+            ('y_weights', (behavior, num_lv)),
+            ('x_scores', (subj, num_lv)),
+            ('y_scores', (subj, num_lv))
         ]
 
         return attrs

--- a/pyls/tests/types/test_regression.py
+++ b/pyls/tests/types/test_regression.py
@@ -1,0 +1,71 @@
+# -*- coding: utf-8 -*-
+
+import numpy as np
+import pytest
+import pyls
+
+Xf = 1000
+Yf = 100
+subj = 50
+rs = np.random.RandomState(1234)
+
+
+class PLSRegressionTests():
+    defaults = pyls.structures.PLSInputs(X=rs.rand(subj, Xf),
+                                         Y=rs.rand(subj, Yf),
+                                         n_perm=20, n_boot=10,
+                                         ci=95, seed=rs, verbose=False)
+
+    def __init__(self, n_components=None, **kwargs):
+        self.inputs = pyls.structures.PLSInputs(**{key: kwargs.get(key, val)
+                                                   for (key, val) in
+                                                   self.defaults.items()})
+        self.inputs['n_components'] = n_components
+        self.output = pyls.pls_regression(**self.inputs)
+        self.confirm_outputs()
+
+    def make_outputs(self):
+        """
+        Used to make list of expected attributes and shapes for PLS outputs
+
+        Returns
+        -------
+        attrs : list-of-tuples
+            Each entry in the list is a tuple with the attribute name and
+            expected shape
+        """
+
+        if self.inputs['n_components'] is None:
+            num_lv = subj - 1
+        else:
+            num_lv = self.inputs['n_components']
+
+        attrs = [
+            ('x_weights', (Xf, num_lv)),
+            ('x_scores', (subj, num_lv)),
+            ('y_scores', (subj, num_lv)),
+            ('y_loadings', (Yf, num_lv)),
+            ('varexp', (num_lv,)),
+        ]
+
+        return attrs
+
+    def confirm_outputs(self):
+        """ Confirms generated outputs are of expected shape / size """
+        for (attr, shape) in self.make_outputs():
+            assert attr in self.output
+            assert self.output[attr].shape == shape
+
+
+@pytest.mark.parametrize('n_components', [
+    None, 2, 5, 10, 15
+])
+def test_behavioral_onegroup_onecondition(n_components):
+    PLSRegressionTests(n_components=n_components)
+
+
+def test_errors():
+    with pytest.raises(ValueError):
+        PLSRegressionTests(n_components=1000)
+    with pytest.raises(ValueError):
+        PLSRegressionTests(Y=rs.rand(subj - 1, Yf))

--- a/pyls/tests/types/test_svd.py
+++ b/pyls/tests/types/test_svd.py
@@ -10,7 +10,7 @@ subj = 100
 rs = np.random.RandomState(1234)
 
 
-class PLSBaseTest():
+class PLSSVDTest():
     defaults = pyls.structures.PLSInputs(X=rs.rand(subj, Xf),
                                          Y=rs.rand(subj, Yf),
                                          groups=None, n_cond=1,
@@ -48,10 +48,11 @@ class PLSBaseTest():
 
         attrs = [
             ('x_weights', (Xf, num_lv)),
-            ('singvals', (num_lv,)),
             ('y_weights', (behavior, num_lv)),
+            ('singvals', (num_lv,)),
+            ('varexp', (num_lv,)),
             ('x_scores', (subj, num_lv)),
-            ('y_scores', (subj, num_lv))
+            ('y_scores', (subj, num_lv)),
         ]
 
         return attrs
@@ -59,40 +60,40 @@ class PLSBaseTest():
     def confirm_outputs(self):
         """ Confirms generated outputs are of expected shape / size """
         for (attr, shape) in self.make_outputs():
-            assert hasattr(self.output, attr)
-            assert getattr(self.output, attr).shape == shape
+            assert attr in self.output
+            assert self.output[attr].shape == shape
 
 
 @pytest.mark.parametrize(('n_split', 'rotate'), [
     (None, True), (None, False), (5, True), (5, False)
 ])
 def test_behavioral_onegroup_onecondition(n_split, rotate):
-    PLSBaseTest('behavioral', groups=None, n_cond=1, n_split=n_split,
-                rotate=rotate)
+    PLSSVDTest('behavioral', groups=None, n_cond=1, n_split=n_split,
+               rotate=rotate)
 
 
 @pytest.mark.parametrize(('n_split', 'rotate'), [
     (None, True), (None, False), (5, True), (5, False)
 ])
 def test_behavioral_multigroup_onecondition(n_split, rotate):
-    PLSBaseTest('behavioral', groups=[33, 34, 33], n_cond=1, n_split=n_split,
-                rotate=rotate)
+    PLSSVDTest('behavioral', groups=[33, 34, 33], n_cond=1, n_split=n_split,
+               rotate=rotate)
 
 
 @pytest.mark.parametrize(('n_split', 'rotate'), [
     (None, True), (None, False), (5, True), (5, False)
 ])
 def test_behavioral_onegroup_multicondition(n_split, rotate):
-    PLSBaseTest('behavioral', groups=subj // 4, n_cond=4, n_split=n_split,
-                rotate=rotate)
+    PLSSVDTest('behavioral', groups=subj // 4, n_cond=4, n_split=n_split,
+               rotate=rotate)
 
 
 @pytest.mark.parametrize(('n_split', 'rotate'), [
     (None, True), (None, False), (5, True), (5, False)
 ])
 def test_behavioral_multigroup_multicondition(n_split, rotate):
-    PLSBaseTest('behavioral', groups=[25, 25], n_cond=2, n_split=n_split,
-                rotate=rotate)
+    PLSSVDTest('behavioral', groups=[25, 25], n_cond=2, n_split=n_split,
+               rotate=rotate)
 
 
 @pytest.mark.parametrize(('mean_centering', 'n_split', 'rotate'), [
@@ -100,8 +101,8 @@ def test_behavioral_multigroup_multicondition(n_split, rotate):
     (2, None, True), (2, None, False), (2, 5, True), (2, 5, False)
 ])
 def test_meancentered_multigroup_onecondition(mean_centering, n_split, rotate):
-    PLSBaseTest('meancentered', groups=[33, 34, 33], n_cond=1, n_split=n_split,
-                mean_centering=mean_centering, rotate=rotate)
+    PLSSVDTest('meancentered', groups=[33, 34, 33], n_cond=1, n_split=n_split,
+               mean_centering=mean_centering, rotate=rotate)
 
 
 @pytest.mark.parametrize(('mean_centering', 'n_split', 'rotate'), [
@@ -109,8 +110,8 @@ def test_meancentered_multigroup_onecondition(mean_centering, n_split, rotate):
     (2, None, True), (2, None, False), (2, 5, True), (2, 5, False)
 ])
 def test_meancentered_onegroup_multicondition(mean_centering, n_split, rotate):
-    PLSBaseTest('meancentered', groups=subj // 2, n_cond=2, n_split=n_split,
-                mean_centering=mean_centering, rotate=rotate)
+    PLSSVDTest('meancentered', groups=subj // 2, n_cond=2, n_split=n_split,
+               mean_centering=mean_centering, rotate=rotate)
 
 
 @pytest.mark.parametrize(('mean_centering', 'n_split', 'rotate'), [
@@ -120,23 +121,23 @@ def test_meancentered_onegroup_multicondition(mean_centering, n_split, rotate):
 ])
 def test_meancentered_multigroup_multicondition(mean_centering, n_split,
                                                 rotate):
-    PLSBaseTest('meancentered', groups=[25, 25], n_cond=2, n_split=n_split,
-                mean_centering=mean_centering, rotate=rotate)
+    PLSSVDTest('meancentered', groups=[25, 25], n_cond=2, n_split=n_split,
+               mean_centering=mean_centering, rotate=rotate)
 
 
 def test_warnings():
     with pytest.warns(UserWarning):
-        PLSBaseTest('meancentered', groups=[50, 50], mean_centering=0)
+        PLSSVDTest('meancentered', groups=[50, 50], mean_centering=0)
     with pytest.warns(UserWarning):
-        PLSBaseTest('meancentered', n_cond=2, mean_centering=1)
+        PLSSVDTest('meancentered', n_cond=2, mean_centering=1)
 
 
 def test_errors():
     with pytest.raises(ValueError):
-        PLSBaseTest('meancentered', groups=[50, 50], mean_centering=3)
+        PLSSVDTest('meancentered', groups=[50, 50], mean_centering=3)
     with pytest.raises(ValueError):
-        PLSBaseTest('meancentered', groups=[subj])
+        PLSSVDTest('meancentered', groups=[subj])
     with pytest.raises(ValueError):
-        PLSBaseTest('meancentered', n_cond=3)
+        PLSSVDTest('meancentered', n_cond=3)
     with pytest.raises(ValueError):
-        PLSBaseTest('behavioral', Y=rs.rand(subj - 1, Yf))
+        PLSSVDTest('behavioral', Y=rs.rand(subj - 1, Yf))

--- a/pyls/types/__init__.py
+++ b/pyls/types/__init__.py
@@ -3,7 +3,8 @@
 The primary PLS decomposition methods for use in conducting PLS analyses
 """
 
-__all__ = ['behavioral_pls', 'meancentered_pls']
+__all__ = ['behavioral_pls', 'meancentered_pls', 'pls_regression']
 
 from .behavioral import behavioral_pls
 from .meancentered import meancentered_pls
+from .regression import pls_regression

--- a/pyls/types/regression.py
+++ b/pyls/types/regression.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 
 import numpy as np
+from ..base import BasePLS
+from ..structures import _pls_input_docs
 from .. import compute
 
 
@@ -24,47 +26,56 @@ def simpls(X, Y, n_components=None, seed=1234):
     Returns
     -------
     results : dict
-        Dictionary with x- and y-loadings / scores / weights / residuals,
+        Dictionary with x- and y-loadings / scores / residuals, x-weights,
         betas, percent variance explained, mse, and T2 values
+
+    References
+    ----------
+    https://www.mathworks.com/help/stats/plsregress.html
     """
 
     X, Y = np.asanyarray(X), np.asanyarray(Y)
     if n_components is None:
-        n_components = min(min(X.shape), min(Y.shape))
+        n_components = min(len(X) - 1, X.shape[1])
 
+    # center variables and calculate covariance matrix
     X0 = (X - X.mean(axis=0))
     Y0 = (Y - Y.mean(axis=0))
+    Cov = X0.T @ Y0
 
+    # to store outputs
     x_loadings = np.zeros((X.shape[1], n_components))
     y_loadings = np.zeros((Y.shape[1], n_components))
     x_scores = np.zeros((X.shape[0], n_components))
     y_scores = np.zeros((X.shape[0], n_components))
     x_weights = np.zeros((X.shape[1], n_components))
-    y_weights = np.zeros((Y.shape[1], n_components))
-
     V = np.zeros((X.shape[1], n_components))
 
-    Cov = X0.T @ Y0
-
     for comp in range(n_components):
+        # get first component of SVD of covariance matrix
         ci, si, ri = compute.svd(Cov, n_components=1, seed=seed)
 
         ti = X0 @ ri
         normti = np.linalg.norm(ti)
-        ti /= normti
-        x_loadings[:, [comp]] = X0.T @ ti
 
-        qi = (si * ci) / normti
-        y_loadings[:, [comp]] = qi
-
-        x_scores[:, [comp]] = ti
-        y_scores[:, [comp]] = Y0 @ qi
-
+        # rescale such that:
+        #     np.diag(x_weights.T @ X0.T @ X0 @ x_weights)
+        #     == np.diag(x_scores.T @ x_scores)
+        #     == 1
         x_weights[:, [comp]] = ri / normti
-        y_weights[:, [comp]] = ci / np.linalg.norm(y_scores[:, [comp]])
 
+        # rescale such that np.diag(x_scores.T @ x_scores) == 1
+        ti /= normti
+        x_scores[:, [comp]] = ti
+
+        x_loadings[:, [comp]] = X0.T @ ti  # == X0.T @ X0 @ x_weights
+        qi = Y0.T @ ti
+        y_loadings[:, [comp]] = qi
+        y_scores[:, [comp]] = Y0 @ qi  # == Y0 @ Y0.T @ x_scores
+
+        # update the orthonormal basis with modified Gram Schmidt; repeat twice
+        # for additional stability
         vi = x_loadings[:, [comp]]
-
         for repeat in range(2):
             for j in range(comp):
                 vj = V[:, [j]]
@@ -72,10 +83,20 @@ def simpls(X, Y, n_components=None, seed=1234):
         vi /= np.linalg.norm(vi)
         V[:, [comp]] = vi
 
+        # deflate Cov, i.e. project onto ortho-complement of the x_loadings.
+        # first, remove projections along the current basis vector, then remove
+        # any component along previous basis vectors that's crept in as noise
+        # from previous deflations.
         Cov = Cov - (vi @ (vi.T @ Cov))
         Vi = V[:, :comp]
         Cov = Cov - (Vi @ (Vi.T @ Cov))
 
+    # by convention, orthogonalize the y_scores w.r.t. the preceding x_scores,
+    # i.e. x_scores.T @ y_scores will be lower triangular. this gives, in
+    # effect, only the "new" contribution to the y_scores for each PLS
+    # component. it is also consistent with the PLS-1/PLS-2 algorithms, where
+    # the y_scores are computed as linear combinations of a successively-
+    # deflated Y0. use modified Gram-Schmidt, repeated twice for stability.
     for comp in range(n_components):
         ui = y_scores[:, [comp]]
         for repeat in range(2):
@@ -85,14 +106,17 @@ def simpls(X, Y, n_components=None, seed=1234):
 
         y_scores[:, [comp]] = ui
 
+    # calculate betas and add intercept
     beta = x_weights @ y_loadings.T
-    beta = np.row_stack([Y.mean(0) - (X.mean(0) @ beta), beta])
+    beta = np.row_stack([Y.mean(axis=0) - (X.mean(axis=0) @ beta), beta])
 
+    # percent variance explained for both X and Y for all components
     pctvar = [
-        np.sum(np.abs(x_loadings) ** 2, 0) / np.sum(np.abs(X0)**2),
-        np.sum(np.abs(y_loadings) ** 2, 0) / np.sum(np.abs(Y0)**2)
+        np.sum(x_loadings ** 2, axis=0) / np.sum(X0 ** 2),
+        np.sum(y_loadings ** 2, axis=0) / np.sum(Y0 ** 2)
     ]
 
+    # mean squared error for models
     mse = np.zeros((2, n_components + 1))
     mse[0, 0] = np.sum(np.abs(X0) ** 2)
     mse[1, 0] = np.sum(np.abs(Y0) ** 2)
@@ -103,13 +127,12 @@ def simpls(X, Y, n_components=None, seed=1234):
         mse[1, i + 1] = np.sum(np.abs(Y0 - Y0_recon) ** 2)
     mse /= len(X)
 
-    t2 = np.sum((np.abs(x_scores) ** 2) / np.var(x_scores, 0, ddof=1), 1)
+    t2 = np.sum((np.abs(x_scores) ** 2) / np.var(x_scores, axis=0, ddof=1), 1)
     x_residuals = X0 - X0_recon
     y_residuals = Y0 - Y0_recon
 
     return dict(
         x_weights=x_weights,
-        y_weights=y_weights,
         x_loadings=x_loadings,
         y_loadings=y_loadings,
         x_scores=x_scores,
@@ -121,3 +144,98 @@ def simpls(X, Y, n_components=None, seed=1234):
         mse=mse,
         t2=t2,
     )
+
+
+class PLSRegression(BasePLS):
+    def __init__(self, X, Y, *, n_components=None, n_perm=5000, n_boot=5000,
+                 seed=None, verbose=True, n_proc=None, **kwargs):
+
+        # check that inputs are valid
+        if len(X) != len(Y):
+            raise ValueError('Provided `X` and `Y` matrices must have the '
+                             'same number of samples. Provided matrices '
+                             'differed: X: {}, Y: {}'.format(len(X), len(Y)))
+
+        max_components = min(len(X) - 1, X.shape[1])
+        if n_components is None:
+            n_components = max_components
+        else:
+            if not isinstance(n_components, int):
+                raise ValueError('Provided `n_components` must be integer.')
+            if n_components > max_components:
+                raise ValueError('Provided `n_components` cannot be greater '
+                                 'than {}'.format(max_components))
+
+        super().__init__(X=np.asarray(X), Y=np.asarray(Y),
+                         n_perm=n_perm, n_boot=n_boot,
+                         n_split=0, test_split=0,
+                         seed=seed, verbose=verbose,
+                         n_proc=n_proc, **kwargs)
+
+        # mean-center here so that our outputs are generated accordingly
+        X = self.inputs.X - self.inputs.X.mean(axis=0, keepdims=True)
+        Y = self.inputs.Y - self.inputs.Y.mean(axis=0, keepdims=True)
+        self.n_components = n_components
+        self.results = self.run_pls(X, Y, n_components)
+
+    def make_permutation(self, X, Y, perminds):
+        return X, Y[perminds]
+
+    def _single_boot(self, X, Y, inds, groups=None, original=None, seed=None):
+        res = simpls(X[inds], Y[inds], self.n_components, seed=seed)
+        return None, res['x_weights']
+
+    def _single_perm(self, X, Y, inds, groups=None, original=None, seed=None):
+        Xp, Yp = self.make_permutation(X, Y, inds)
+        res = simpls(Xp, Yp, self.n_components, seed=seed)['pctvar'][1]
+        return res, None, None
+
+    def svd(self, X, Y, groups=None, seed=None):
+        res = simpls(X, Y, self.n_components, seed=seed)
+        return res['x_weights'], res['pctvar'], None
+
+    def run_pls(self, X, Y, n_components=None):
+        res = super().run_pls(X, Y)
+
+        if self.inputs.n_boot > 0:
+            u_sum, u_square = self.bootstrap(X, Y, self.rs)[1:]
+            u_sum, u_square = u_sum + res.u, u_square + (res.u ** 2)
+            bsrs, uboot_se = compute.boot_rel(res.u, u_sum, u_square,
+                                              self.inputs.n_boot + 1)
+            res.bootres.update(dict(bootstrapratios=bsrs,
+                                    uboot_se=uboot_se,
+                                    bootsamples=self.bootsamp))
+        return res
+
+
+# let's make it a function
+def pls_regression(X, Y, *, n_components=None, n_perm=5000, n_boot=5000,
+                   seed=None, verbose=True, n_proc=None, **kwargs):
+    pls = PLSRegression(X=X, Y=Y, n_components=n_components,
+                        n_perm=n_perm, n_boot=n_boot,
+                        seed=seed, verbose=verbose, n_proc=n_proc, **kwargs)
+    return pls.results
+
+
+pls_regression.__doc__ = r"""
+Performs PLS Regression on `X` and `Y`.
+
+PLS regression is a multivariate statistical approach that relates two sets
+of variables together. Traditionally, one of these arrays
+represents a set of brain features (e.g., functional connectivity
+estimates) and the other represents a set of behavioral variables; however,
+these arrays can be any two sets of features belonging to a common group of
+samples.
+
+Parameters
+----------
+{input_matrix}
+Y : (S, T) array_like
+    Input data matrix, where `S` is samples and `T` is features
+{stat_test}
+{proc_options}
+
+Returns
+----------
+{pls_results}
+""".format(**_pls_input_docs)

--- a/pyls/types/regression.py
+++ b/pyls/types/regression.py
@@ -6,6 +6,45 @@ from ..structures import _pls_input_docs
 from .. import compute
 
 
+def resid_yscores(x_scores, y_scores, copy=True):
+    """
+    Orthogonalizes `y_scores` with respect to preceding `x_scores`
+
+    Residualizes each column of `y_scores` against all previous columns of
+    `x_scores` such that the column represents only the "new" contributions of
+    each PLS component
+
+    Parameters
+    ----------
+    x_scores : (S, L) array_like
+        Projections of X data matrix into PLS-derived component space
+    y_scores : (S, L) array_like
+        Projections of Y data matrix into PLS-derived component space
+    copy : bool, optional
+        Whether to copy `y_scores` instead of overwriting in-place. Default:
+        True
+
+    Returns
+    -------
+    y_scores : (S, L) numpy.ndarray
+        Residualized `y_scores`
+    """
+
+    x_scores = np.array(x_scores)
+    y_scores = np.array(y_scores, copy=copy)
+
+    for comp in range(x_scores.shape[1]):
+        ui = y_scores[:, [comp]]
+        for _ in range(2):
+            for j in range(comp):
+                tj = x_scores[:, [j]]
+                ui = ui - ((tj.T @ ui) * tj)
+
+        y_scores[:, [comp]] = ui
+
+    return y_scores
+
+
 def simpls(X, Y, n_components=None, seed=1234):
     """
     Performs partial least squares regression with the SIMPLS algorithm
@@ -39,8 +78,8 @@ def simpls(X, Y, n_components=None, seed=1234):
         n_components = min(len(X) - 1, X.shape[1])
 
     # center variables and calculate covariance matrix
-    X0 = (X - X.mean(axis=0))
-    Y0 = (Y - Y.mean(axis=0))
+    X0 = (X - X.mean(axis=0, keepdims=True))
+    Y0 = (Y - Y.mean(axis=0, keepdims=True))
     Cov = X0.T @ Y0
 
     # to store outputs
@@ -97,14 +136,7 @@ def simpls(X, Y, n_components=None, seed=1234):
     # component. it is also consistent with the PLS-1/PLS-2 algorithms, where
     # the y_scores are computed as linear combinations of a successively-
     # deflated Y0. use modified Gram-Schmidt, repeated twice for stability.
-    for comp in range(n_components):
-        ui = y_scores[:, [comp]]
-        for repeat in range(2):
-            for j in range(comp):
-                tj = x_scores[:, [j]]
-                ui = ui - ((tj.T @ ui) * tj)
-
-        y_scores[:, [comp]] = ui
+    y_scores = resid_yscores(x_scores, y_scores)
 
     # calculate betas and add intercept
     beta = x_weights @ y_loadings.T
@@ -148,14 +180,10 @@ def simpls(X, Y, n_components=None, seed=1234):
 
 class PLSRegression(BasePLS):
     def __init__(self, X, Y, *, n_components=None, n_perm=5000, n_boot=5000,
-                 seed=None, verbose=True, n_proc=None, **kwargs):
+                 ci=95, seed=None, verbose=True, n_proc=None, permsamples=None,
+                 bootsamples=None, **kwargs):
 
-        # check that inputs are valid
-        if len(X) != len(Y):
-            raise ValueError('Provided `X` and `Y` matrices must have the '
-                             'same number of samples. Provided matrices '
-                             'differed: X: {}, Y: {}'.format(len(X), len(Y)))
-
+        # check n_components isn't unreasonable
         max_components = min(len(X) - 1, X.shape[1])
         if n_components is None:
             n_components = max_components
@@ -167,65 +195,164 @@ class PLSRegression(BasePLS):
                                  'than {}'.format(max_components))
 
         super().__init__(X=np.asarray(X), Y=np.asarray(Y),
-                         n_perm=n_perm, n_boot=n_boot,
-                         n_split=0, test_split=0,
+                         n_components=n_components, n_perm=n_perm,
+                         n_boot=n_boot, n_split=0, test_split=0, ci=ci,
                          seed=seed, verbose=verbose,
-                         n_proc=n_proc, **kwargs)
+                         n_proc=n_proc, permsamples=permsamples,
+                         bootsamples=bootsamples, **kwargs)
 
         # mean-center here so that our outputs are generated accordingly
         X = self.inputs.X - self.inputs.X.mean(axis=0, keepdims=True)
         Y = self.inputs.Y - self.inputs.Y.mean(axis=0, keepdims=True)
         self.n_components = n_components
-        self.results = self.run_pls(X, Y, n_components)
 
-    def make_permutation(self, X, Y, perminds):
-        return X, Y[perminds]
+        self.results = self.run_pls(X, Y)
+
+    def svd(self, X, Y, seed=None):
+        """
+        Runs PLS decomposition with `X` and `Y`
+
+        Parameters
+        ----------
+        X : (S, B) array_like
+            Input data matrix, where `S` is observations and `B` is features
+        Y : (S, T) array_like
+            Input data matrix, where `S` is observations and `T` is features
+        seed : {int, :obj:`numpy.random.RandomState`, None}, optional
+            Seed for random number generation. Default: None
+
+        Returns
+        -------
+        x_weights : (B, L) numpy.ndarray
+            Weights of `B` features used to project `X` into PLS-derived
+            component space
+        varexp : (L, L) numpy.ndarray
+            Variance explained by PLS-derived components; diagonal array
+        """
+
+        out = simpls(X, Y, self.n_components, seed=seed)
+
+        # need to return len-3 for compatibility purposes
+        # use the variance explained in Y in lieu of the singular values since
+        # that's what we'll be testing against in permutations
+        return out['x_weights'], np.diag(out['pctvar'][1]), None
 
     def _single_boot(self, X, Y, inds, groups=None, original=None, seed=None):
-        # should we be aligning these to the `original` somehow?
-        res = simpls(X[inds], Y[inds], self.n_components, seed=seed)
-        return None, res['x_weights']
+        """
+        Bootstraps `X` and `Y` (w/replacement) and recomputes PLS decomposition
+
+        Parameters
+        ----------
+        X : (S, B) array_like
+            Input data matrix, where `S` is observations and `B` is features
+        Y : (S, T) array_like
+            Input data matrix, where `S` is observations and `T` is features
+        inds : (S,) array_like
+            Resampling array
+        groups,original : None
+            Do nothing; here for compatibility purposes
+        seed : {int, :obj:`numpy.random.RandomState`, None}, optional
+            Seed for random number generation. Default: None
+
+        Returns
+        -------
+        y_loadings : (T, L) np.ndarray
+            Loadings of `Y` on PLS decomposition from resampled data
+        x_weights : (B, L) np.ndarray
+            Weights of `X` from PLS decomposition of resampled data
+        """
+
+        # TODO: should we be aligning these to the `original` somehow?
+        out = simpls(X[inds], Y[inds], self.n_components, seed=seed)
+        y_loadings = Y[inds].T @ out['x_scores']
+
+        return y_loadings, out['x_weights']
 
     def _single_perm(self, X, Y, inds, groups=None, original=None, seed=None):
-        # should we be aligning these to the `original` somehow?
+        """
+        Permutes `Y` (w/o replacement) and recomputes PLS decomposition
+
+        Parameters
+        ----------
+        X : (S, B) array_like
+            Input data matrix, where `S` is observations and `B` is features
+        Y : (S, T) array_like
+            Input data matrix, where `S` is observations and `T` is features
+        inds : (S,) array_like
+            Resampling array
+        groups,original : None
+            Do nothing; here for compatibility purposes
+        seed : {int, :obj:`numpy.random.RandomState`, None}, optional
+            Seed for random number generation. Default: None
+
+        Returns
+        -------
+        varexp : (L,) `numpy.ndarray`
+            Variance explained by PLS decomposition of permuted data
+        """
+
+        # TODO: should we be aligning these to the `original` somehow?
         Xp, Yp = self.make_permutation(X, Y, inds)
-        res = simpls(Xp, Yp, self.n_components, seed=seed)['pctvar'][1]
-        return res, None, None
+        varexp = simpls(Xp, Yp, self.n_components, seed=seed)['pctvar'][1]
 
-    def svd(self, X, Y, groups=None, seed=None):
-        res = simpls(X, Y, self.n_components, seed=seed)
-        return res['x_weights'], np.diag(res['pctvar'][1]), None
+        # need to return len-3 for compatibility purposes
+        return varexp, None, None
 
-    def run_pls(self, X, Y, n_components=None):
+    def run_pls(self, X, Y):
+        """
+        Runs PLS analysis
+
+        Parameters
+        ----------
+        X : (S, B) array_like
+            Input data matrix, where `S` is observations and `B` is features
+        Y : (S, T) array_like
+            Input data matrix, where `S` is observations and `T` is features
+        """
+
         res = super().run_pls(X, Y)
-
-        # don't keep this as a diagonal matrix
-        res.s = np.diag(res.s)
+        res['y_loadings'] = Y.T @ res['x_scores']
+        res['y_scores'] = resid_yscores(res['x_scores'], Y @ res['y_loadings'])
 
         if self.inputs.n_boot > 0:
-            u_sum, u_square = self.bootstrap(X, Y, self.rs)[1:]
+            # compute bootstraps
+            distrib, u_sum, u_square = self.bootstrap(X, Y, self.rs)
+
             # add original weights back in so we account for those
-            u_sum, u_square = u_sum + res.u, u_square + (res.u ** 2)
+            bs = res['x_weights']
+            u_sum, u_square = u_sum + bs, u_square + (bs ** 2)
+
             # calculate normalized ratios + bootstrap errors
-            bsrs, uboot_se = compute.boot_rel(res.u, u_sum, u_square,
+            bsrs, uboot_se = compute.boot_rel(bs, u_sum, u_square,
                                               self.inputs.n_boot + 1)
-            res.bootres.update(dict(bootstrapratios=bsrs,
-                                    uboot_se=uboot_se,
-                                    bootsamples=self.bootsamp))
+            corrci = np.stack(compute.boot_ci(distrib, ci=self.inputs.ci), -1)
+            res['bootres'].update(dict(x_weights_normed=bsrs,
+                                       x_weights_stderr=uboot_se,
+                                       y_loadings=res['y_loadings'].copy(),
+                                       y_loadings_boot=distrib,
+                                       y_loadings_ci=corrci,
+                                       bootsamples=self.bootsamp,))
+
+        # don't keep this as a diagonal matrix
+        res['varexp'] = np.diag(res['singvals'])
+        del res['singvals']
+
         return res
 
 
 # let's make it a function
-def pls_regression(X, Y, *, n_components=None, n_perm=5000, n_boot=5000,
-                   seed=None, verbose=True, n_proc=None, **kwargs):
-    pls = PLSRegression(X=X, Y=Y, n_components=n_components,
-                        n_perm=n_perm, n_boot=n_boot,
-                        seed=seed, verbose=verbose, n_proc=n_proc, **kwargs)
+def pls_regression(X, Y, *, n_components=None, n_perm=5000, n_boot=5000, ci=95,
+                   permsamples=None, bootsamples=None, seed=None, verbose=True,
+                   n_proc=None, **kwargs):
+    pls = PLSRegression(X=X, Y=Y, n_components=n_components, n_perm=n_perm,
+                        n_boot=n_boot, ci=ci, permsamples=permsamples,
+                        bootsamples=bootsamples, seed=seed, verbose=verbose,
+                        n_proc=n_proc, **kwargs)
     return pls.results
 
 
 pls_regression.__doc__ = r"""
-Performs PLS Regression on `X` and `Y`.
+Performs PLS regression on `X` and `Y`
 
 PLS regression is a multivariate statistical approach that relates two sets
 of variables together. Traditionally, one of these arrays
@@ -233,6 +360,8 @@ represents a set of brain features (e.g., functional connectivity
 estimates) and the other represents a set of behavioral variables; however,
 these arrays can be any two sets of features belonging to a common group of
 samples.
+
+This implementation of PLS regression uses the SIMPLS algorithm from [R1]_.
 
 Parameters
 ----------
@@ -243,9 +372,22 @@ n_components : int, optional
     Number of components to estimate. If not specified this will be set to
     min(`S-1`, `B`). Default: None
 {stat_test}
+{ci}
+{resamples}
 {proc_options}
 
 Returns
 ----------
 {pls_results}
+
+References
+----------
+.. [R1] De Jong, S. (1993). SIMPLS: an alternative approach to partial least
+   squares regression. Chemometrics and intelligent laboratory systems, 18(3),
+   251-263.
+.. [R2] Rosipal, R., & Krämer, N. (2005, February). Overview and recent
+   advances in partial least squares. In International Statistical and
+   Optimization Perspectives Workshop" Subspace, Latent Structure and Feature
+   Selection" (pp. 34-51). Springer, Berlin, Heidelberg.
+.. [R3] https://www.mathworks.com/help/stats/plsregress.html
 """.format(**_pls_input_docs)

--- a/pyls/types/regression.py
+++ b/pyls/types/regression.py
@@ -1,0 +1,123 @@
+# -*- coding: utf-8 -*-
+
+import numpy as np
+from .. import compute
+
+
+def simpls(X, Y, n_components=None, seed=1234):
+    """
+    Performs partial least squares regression with the SIMPLS algorithm
+
+    Parameters
+    ----------
+    X : (S, B) array_like
+        Input data matrix, where `S` is observations and `B` is features
+    Y : (S, T) array_like
+        Input data matrix, where `S` is observations and `T` is features
+    n_components : int, optional
+        Number of components to estimate. If not specified will use the
+        smallest of the input X and Y dimensions. Default: None
+    seed : {int, :obj:`numpy.random.RandomState`, None}, optional
+        Seed to use for random number generation. Helps ensure reproducibility
+        of results. Default: None
+
+    Returns
+    -------
+    results : dict
+        Dictionary with x- and y-loadings / scores / weights / residuals,
+        betas, percent variance explained, mse, and T2 values
+    """
+
+    X, Y = np.asanyarray(X), np.asanyarray(Y)
+    if n_components is None:
+        n_components = min(min(X.shape), min(Y.shape))
+
+    X0 = (X - X.mean(axis=0))
+    Y0 = (Y - Y.mean(axis=0))
+
+    x_loadings = np.zeros((X.shape[1], n_components))
+    y_loadings = np.zeros((Y.shape[1], n_components))
+    x_scores = np.zeros((X.shape[0], n_components))
+    y_scores = np.zeros((X.shape[0], n_components))
+    x_weights = np.zeros((X.shape[1], n_components))
+    y_weights = np.zeros((Y.shape[1], n_components))
+
+    V = np.zeros((X.shape[1], n_components))
+
+    Cov = X0.T @ Y0
+
+    for comp in range(n_components):
+        ci, si, ri = compute.svd(Cov, n_components=1, seed=seed)
+
+        ti = X0 @ ri
+        normti = np.linalg.norm(ti)
+        ti /= normti
+        x_loadings[:, [comp]] = X0.T @ ti
+
+        qi = (si * ci) / normti
+        y_loadings[:, [comp]] = qi
+
+        x_scores[:, [comp]] = ti
+        y_scores[:, [comp]] = Y0 @ qi
+
+        x_weights[:, [comp]] = ri / normti
+        y_weights[:, [comp]] = ci / np.linalg.norm(y_scores[:, [comp]])
+
+        vi = x_loadings[:, [comp]]
+
+        for repeat in range(2):
+            for j in range(comp):
+                vj = V[:, [j]]
+                vi = vi - ((vj.T @ vi) * vj)
+        vi /= np.linalg.norm(vi)
+        V[:, [comp]] = vi
+
+        Cov = Cov - (vi @ (vi.T @ Cov))
+        Vi = V[:, :comp]
+        Cov = Cov - (Vi @ (Vi.T @ Cov))
+
+    for comp in range(n_components):
+        ui = y_scores[:, [comp]]
+        for repeat in range(2):
+            for j in range(comp):
+                tj = x_scores[:, [j]]
+                ui = ui - ((tj.T @ ui) * tj)
+
+        y_scores[:, [comp]] = ui
+
+    beta = x_weights @ y_loadings.T
+    beta = np.row_stack([Y.mean(0) - (X.mean(0) @ beta), beta])
+
+    pctvar = [
+        np.sum(np.abs(x_loadings) ** 2, 0) / np.sum(np.abs(X0)**2),
+        np.sum(np.abs(y_loadings) ** 2, 0) / np.sum(np.abs(Y0)**2)
+    ]
+
+    mse = np.zeros((2, n_components + 1))
+    mse[0, 0] = np.sum(np.abs(X0) ** 2)
+    mse[1, 0] = np.sum(np.abs(Y0) ** 2)
+    for i in range(n_components):
+        X0_recon = x_scores[:, :i + 1] @ x_loadings[:, :i + 1].T
+        Y0_recon = x_scores[:, :i + 1] @ y_loadings[:, :i + 1].T
+        mse[0, i + 1] = np.sum(np.abs(X0 - X0_recon) ** 2)
+        mse[1, i + 1] = np.sum(np.abs(Y0 - Y0_recon) ** 2)
+    mse /= len(X)
+
+    t2 = np.sum((np.abs(x_scores) ** 2) / np.var(x_scores, 0, ddof=1), 1)
+    x_residuals = X0 - X0_recon
+    y_residuals = Y0 - Y0_recon
+
+    return dict(
+        x_weights=x_weights,
+        y_weights=y_weights,
+        x_loadings=x_loadings,
+        y_loadings=y_loadings,
+        x_scores=x_scores,
+        y_scores=y_scores,
+        x_residuals=x_residuals,
+        y_residuals=y_residuals,
+        beta=beta,
+        pctvar=pctvar,
+        mse=mse,
+        t2=t2,
+    )

--- a/pyls/utils.py
+++ b/pyls/utils.py
@@ -49,6 +49,8 @@ class ResDict(Bunch):
         # potentially recursive checks if sub-items are dictionaries
         for k, v in self.items():
             v2 = value.get(k, None)
+            if v is None and v2 is None:
+                continue
             # recursive dictionary comparison
             if isinstance(v, dict) and isinstance(v2, dict):
                 if v != v2:

--- a/setup.cfg
+++ b/setup.cfg
@@ -61,13 +61,13 @@ pyls =
 
 [coverage:run]
 omit =
-    pyls/tests/matlab.py
-    pyls/_version.py
+    */pyls/tests/matlab.py
+    */pyls/_version.py
 
 [flake8]
 doctests = True
 exclude =
-    *build/
+    *build/*
     *sphinx*
     */__init__.py
 ignore = E402, W503


### PR DESCRIPTION
Adds `pyls.pls_regression()` with similar functionality to `behavioral_pls()` but using the SIMPLS algorithm instead of a symmetrical SVD-based decomposition. Notably, adding this functionality required a major overhaul of the `PLSResults` names, which were designed around using SVDs; the results structure names are now more general and apply to both regression and SVD frameworks.

To do:
- [x] Add tests for `pls_regression()` functionality