### PR TITLE
[ENH] Allows 3d arrays in PLS regression

### DIFF
--- a/pyls/structures.py
+++ b/pyls/structures.py
@@ -142,7 +142,7 @@ class PLSInputs(ResDict):
         'X', 'Y', 'groups', 'n_cond', 'n_perm', 'n_boot', 'n_split',
         'test_split', 'test_size', 'mean_centering', 'covariance', 'rotate',
         'ci', 'seed', 'verbose', 'n_proc', 'bootsamples', 'permsamples',
-        'method', 'n_components'
+        'method', 'n_components', 'aggfunc'
     ]
 
     def __init__(self, *args, **kwargs):

--- a/pyls/structures.py
+++ b/pyls/structures.py
@@ -55,7 +55,7 @@ _pls_input_docs = dict(
          Default: 5000
     n_boot : int, optional
         Number of bootstraps to use for testing reliability of data features.
-        Default: 5000
+        Default: 5000\
     """),
     split_half=dedent("""\
     n_split : int, optional
@@ -115,7 +115,7 @@ _pls_input_docs = dict(
     bootsamples : array_like, optional
         Resampling array to be used during bootstrap resampling (if n_boot >
         0). If not specified a set of unique bootstraps will be generated.
-        Default: None
+        Default: None\
     """),
     references=dedent("""\
     McIntosh, A. R., Bookstein, F. L., Haxby, J. V., & Grady, C. L. (1996).

--- a/pyls/tests/types/test_regression.py
+++ b/pyls/tests/types/test_regression.py
@@ -17,9 +17,9 @@ class PLSRegressionTests():
                                          ci=95, seed=rs, verbose=False)
 
     def __init__(self, n_components=None, **kwargs):
-        self.inputs = pyls.structures.PLSInputs(**{key: kwargs.get(key, val)
-                                                   for (key, val) in
-                                                   self.defaults.items()})
+        params = self.defaults.copy()
+        params.update(kwargs)
+        self.inputs = pyls.structures.PLSInputs(**params)
         self.inputs['n_components'] = n_components
         self.output = pyls.pls_regression(**self.inputs)
         self.confirm_outputs()
@@ -64,9 +64,20 @@ def test_regression_onegroup_onecondition(n_components):
     PLSRegressionTests(n_components=n_components)
 
 
-def test_regression_3dbootstrap():
+@pytest.mark.parametrize('aggfunc', [
+    'mean', 'median', 'sum'
+])
+def test_regression_3dbootstrap(aggfunc):
+    # confirm providing 3D arrays works
     Y = rs.rand(subj, Yf, 100)
-    PLSRegressionTests(n_components=2, Y=Y)
+    PLSRegressionTests(Y=Y, n_components=2, aggfunc=aggfunc)
+
+    # confirm providing valid bootsamples for 3D array works
+    sboot = pyls.base.gen_bootsamp([subj], 1, n_boot=10)
+    nboot = pyls.base.gen_bootsamp([100], 1, n_boot=10)
+    bootsamples = np.array(list(zip(sboot.T, nboot.T))).T
+    PLSRegressionTests(Y=Y, n_components=2, aggfunc=aggfunc,
+                       bootsamples=bootsamples, n_boot=10)
 
 
 def test_errors():
@@ -74,3 +85,9 @@ def test_errors():
         PLSRegressionTests(n_components=1000)
     with pytest.raises(ValueError):
         PLSRegressionTests(Y=rs.rand(subj - 1, Yf))
+    with pytest.raises(ValueError):
+        PLSRegressionTests(Y=rs.rand(subj, Yf, 10), aggfunc='notafunc')
+    with pytest.raises(TypeError):
+        PLSRegressionTests(Y=rs.rand(subj, Yf, 10), aggfunc=lambda x: x)
+    with pytest.raises(ValueError):
+        PLSRegressionTests(Y=rs.rand(subj, Yf, 10), bootsamples=[[10], [10]])

--- a/pyls/tests/types/test_regression.py
+++ b/pyls/tests/types/test_regression.py
@@ -60,8 +60,13 @@ class PLSRegressionTests():
 @pytest.mark.parametrize('n_components', [
     None, 2, 5, 10, 15
 ])
-def test_behavioral_onegroup_onecondition(n_components):
+def test_regression_onegroup_onecondition(n_components):
     PLSRegressionTests(n_components=n_components)
+
+
+def test_regression_3dbootstrap():
+    Y = rs.rand(subj, Yf, 100)
+    PLSRegressionTests(n_components=2, Y=Y)
 
 
 def test_errors():

--- a/pyls/types/regression.py
+++ b/pyls/types/regression.py
@@ -357,9 +357,7 @@ class PLSRegression(BasePLS):
             Input data matrix, where `S` is observations and `T` is features
         """
 
-        if Y.ndim == 3:
-            Y_agg = self.aggfunc(Y, axis=-1)
-
+        Y_agg = self.aggfunc(Y, axis=-1) if Y.ndim == 3 else Y
         res = super().run_pls(X, Y_agg)
         res['y_loadings'] = Y_agg.T @ res['x_scores']
         res['y_scores'] = resid_yscores(res['x_scores'],

--- a/pyls/types/regression.py
+++ b/pyls/types/regression.py
@@ -280,7 +280,7 @@ class PLSRegression(BasePLS):
         # if we have a 3d `Y` matrix only bootstrap over the last dimension
         # do NOT bootstrap over `X` at all
         if Y.ndim == 3:
-            Xi, Yi = X, self.aggfunc(Y[..., inds])
+            Xi, Yi = X, self.aggfunc(Y[..., inds], axis=-1)
         else:
             Xi, Yi = X[inds], Y[inds]
 


### PR DESCRIPTION
Assumes that the last axis indexes "subjects" or "observations" which we want to collapse across with some `aggfunc`. During bootstrapping, we resample from this last axis (instead of the first axis).

**To do**:
- [x] Add tests to make sure 3d inputs are handled correctly
- [x] Improve documentation for `aggfunc`
- [x] Better shape checking of all inputs?

(cc @kwagstyl)