### PR TITLE
[FIX] Fixes bad multiprocessing w/joblib v0.14.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -84,7 +84,7 @@ jobs:
           command: |
             . venv/bin/activate
             for mat in /tmp/data/matlab/bpls*mat; do
-              echo "${mat}"
+              echo $( date +%H:%M:%S ) "${mat}"
               python -c "import pyls.tests; pyls.tests.assert_matlab_equivalence('${mat}', n_proc='max', n_perm=2500, n_split=100);"
             done
 
@@ -109,7 +109,7 @@ jobs:
           command: |
             . venv/bin/activate
             for mat in /tmp/data/matlab/mpls*mat; do
-              echo "${mat}"
+              echo $( date +%H:%M:%S ) "${mat}"
               python -c "import pyls.tests; pyls.tests.assert_matlab_equivalence('${mat}', n_proc='max', n_perm=2500, n_split=250);"
             done
 

--- a/pyls/tests/matlab.py
+++ b/pyls/tests/matlab.py
@@ -244,7 +244,7 @@ def assert_matlab_equivalence(fname, method=None, *, atol=1e-4, corr=0.975,
 
     # fix n_split default (if not specified in matlab assume 0)
     if 'n_split' not in matlab['inputs']:
-        matlab['inputs']['n_split'] = 0
+        matlab['inputs']['n_split'] = None
 
     # get PLS method
     fcn = None

--- a/pyls/tests/test_utils.py
+++ b/pyls/tests/test_utils.py
@@ -145,12 +145,12 @@ def test_get_par_func():
 
     if utils.joblib_avail:
         import joblib
-        par, func = utils.get_par_func(1000, fcn)
-        assert isinstance(par, joblib.Parallel)
-        assert par.n_jobs == 1000
-        assert not fcn == func
+        with utils.get_par_func(1000, fcn) as (par, func):
+            assert isinstance(par, joblib.Parallel)
+            assert par.n_jobs == 1000
+            assert not fcn == func
 
         utils.joblib_avail = False
-        par, func = utils.get_par_func(1000, fcn)
-        assert isinstance(par, utils._unravel)
-        assert fcn == func
+        with utils.get_par_func(1000, fcn) as (par, func):
+            assert isinstance(par, utils._unravel)
+            assert fcn == func

--- a/pyls/types/behavioral.py
+++ b/pyls/types/behavioral.py
@@ -113,7 +113,8 @@ class BehavioralPLS(BasePLS):
         gen = utils.trange(self.inputs.test_split, verbose=self.inputs.verbose,
                            desc='Running cross-validation')
         with utils.get_par_func(self.inputs.n_proc,
-                                self.__class__._single_crossval) as (par, func):
+                                self.__class__._single_crossval) as (par,
+                                                                     func):
             out = par(
                 func(self, X=X, Y=Y, inds=splits[:, i], groups=groups, seed=i)
                 for i in gen

--- a/pyls/types/behavioral.py
+++ b/pyls/types/behavioral.py
@@ -110,12 +110,14 @@ class BehavioralPLS(BasePLS):
                             seed=seed,
                             test_size=self.inputs.test_size)
 
-        parallel, func = utils.get_par_func(self.inputs.n_proc,
-                                            self.__class__._single_crossval)
         gen = utils.trange(self.inputs.test_split, verbose=self.inputs.verbose,
                            desc='Running cross-validation')
-        out = parallel(func(self, X=X, Y=Y, inds=splits[:, i],
-                            groups=groups, seed=i) for i in gen)
+        with utils.get_par_func(self.inputs.n_proc,
+                                self.__class__._single_crossval) as (par, func):
+            out = par(
+                func(self, X=X, Y=Y, inds=splits[:, i], groups=groups, seed=i)
+                for i in gen
+            )
         r_scores, r2_scores = [np.stack(o, axis=-1) for o in zip(*out)]
 
         return r_scores, r2_scores

--- a/pyls/utils.py
+++ b/pyls/utils.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 
+from contextlib import contextmanager
+
 import numpy as np
 import tqdm
 from sklearn.utils import Bunch
@@ -267,6 +269,7 @@ class _unravel():
         pass
 
 
+@contextmanager
 def get_par_func(n_proc, func, **kwargs):
     """
     Creates joblib-style parallelization function if joblib is available
@@ -287,10 +290,10 @@ def get_par_func(n_proc, func, **kwargs):
     """
 
     if joblib_avail:
-        parallel = Parallel(n_jobs=n_proc, max_nbytes=1e6, mmap_mode='r+',
-                            **kwargs)
         func = delayed(func)
+        with Parallel(n_jobs=n_proc, max_nbytes=1e6,
+                      mmap_mode='r+', **kwargs) as parallel:
+            yield parallel, func
     else:
         parallel = _unravel()
-
-    return parallel, func
+        yield parallel, func

--- a/pyls/utils.py
+++ b/pyls/utils.py
@@ -161,6 +161,9 @@ def trange(n_iter, verbose=True, **kwargs):
         def update(self, *args, **kwargs):
             return
 
+        def close(self, *args, **kwargs):
+            return
+
     if not verbose:
         return cmrange(n_iter)
 

--- a/pyls/utils.py
+++ b/pyls/utils.py
@@ -144,35 +144,12 @@ def trange(n_iter, verbose=True, **kwargs):
     progbar : :obj:`tqdm.tqdm`
     """
 
-    class cmrange():
-        def __init__(self, n_iter):
-            self.n_iter = n_iter
-
-        def __enter__(self, *args, **kwargs):
-            return self
-
-        def __exit__(self, *args, **kwargs):
-            return
-
-        def __iter__(self):
-            for i in range(self.n_iter):
-                yield i
-
-        def update(self, *args, **kwargs):
-            return
-
-        def close(self, *args, **kwargs):
-            return
-
-    if not verbose:
-        return cmrange(n_iter)
-
     form = ('{desc}: {percentage:3.0f}%|{bar}| {n_fmt}/{total_fmt}'
             ' | {elapsed}<{remaining}')
     defaults = dict(ascii=True, leave=False, bar_format=form)
     defaults.update(kwargs)
 
-    return tqdm.trange(n_iter, **defaults)
+    return tqdm.trange(n_iter, disable=not verbose, **defaults)
 
 
 def dummy_code(groups, n_cond=1):


### PR DESCRIPTION
The recent `joblib` update made it such that we were less able to "stupidly" parallelize during the bootstrapping. Rather than re-using the workers, it was spawning new ones on each loop, causing HUGE delays in the bootstrapping procedure.

This (hopefully) fixes that!