### PR TITLE
[REF] Use numpy-coerced X/Y for PLSRegression

### DIFF
--- a/pyls/types/regression.py
+++ b/pyls/types/regression.py
@@ -234,7 +234,7 @@ class PLSRegression(BasePLS):
                          seed=seed, verbose=verbose, n_proc=n_proc, **kwargs)
 
         self.n_components = n_components
-        self.results = self.run_pls(X, Y)
+        self.results = self.run_pls(self.inputs.X, self.inputs.Y)
 
     def svd(self, X, Y, seed=None):
         """


### PR DESCRIPTION
The pandas.DataFrame.mean method doesn't accept the `keepdims` parameter so providing pandas DataFrames as inputs was failing.