### PR TITLE
[REF] Handle missing data rows in pls_regression

### DIFF
--- a/pyls/tests/types/test_regression.py
+++ b/pyls/tests/types/test_regression.py
@@ -80,6 +80,17 @@ def test_regression_3dbootstrap(aggfunc):
                        bootsamples=bootsamples, n_boot=10)
 
 
+def test_regression_missingdata():
+    X = rs.rand(subj, Xf)
+    X[10] = np.nan
+    PLSRegressionTests(X=X, n_components=2)
+    X[20] = np.nan
+    PLSRegressionTests(X=X, n_components=2)
+    Y = rs.rand(subj, Yf)
+    Y[11] = np.nan
+    PLSRegressionTests(X=X, Y=Y, n_components=2)
+
+
 def test_errors():
     with pytest.raises(ValueError):
         PLSRegressionTests(n_components=1000)


### PR DESCRIPTION
Should (hopefully) "elegantly" handle when X/Y are missing **entire rows** of data during calls to `pyls.pls_regression()`. The function will simply ignore these rows and insert NaNs into the corresponding outputs, as appropriate.

Closes #53 .